### PR TITLE
Fix HastaReader not loading any images.

### DIFF
--- a/src/it/hastareader/src/eu/kanade/tachiyomi/extension/it/hastareader/HastaReader.kt
+++ b/src/it/hastareader/src/eu/kanade/tachiyomi/extension/it/hastareader/HastaReader.kt
@@ -32,6 +32,7 @@ class HastaReader : ParsedHttpSource() {
         val dateFormat by lazy {
             SimpleDateFormat("dd/MM/yyyy")
         }
+
         // HastaReader has a check for adult content on some manga.
         private val adultCheck: RequestBody by lazy {
             FormBody.Builder().apply {
@@ -39,6 +40,9 @@ class HastaReader : ParsedHttpSource() {
             }.build()
         }
     }
+
+    override fun headersBuilder() = super.headersBuilder()
+        .add("Referer", "$baseUrl/slide")
 
     override fun popularMangaSelector() = "div.list > div.group > div.title > a"
 


### PR DESCRIPTION
The HastaReader extension was not loading any thumbnails or pages. Attempts to load images were redirected to home page. Adding 'Referer' to headers fixes this issue.