### PR TITLE
Fix extra (advertisement) page being added in Mangahere.

### DIFF
--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -183,7 +183,9 @@ class Mangahere : ParsedHttpSource() {
 
         val pages = mutableListOf<Page>()
         document.select("select.wid60").first()?.getElementsByTag("option")?.forEach {
-            pages.add(Page(pages.size, "http:" + it.attr("value")))
+            if (!it.attr("value").contains("featured.html")) {
+                pages.add(Page(pages.size, "http:" + it.attr("value")))
+            }
         }
         pages.getOrNull(0)?.imageUrl = imageUrlParse(document)
         return pages


### PR DESCRIPTION
This pull request mirrors [tachiyomi#1052](https://github.com/inorichi/tachiyomi/pull/1052), as the page detection is the same in the Mangahere extension and the parser in Tachiyomi.

An extra page exists at the end of all chapters on Mangahere called "featured.html", but that page has no image, so downloading always fails. I'm not sure when this was added or when it might be removed, but it is no longer added to a chapter's page list.