### PR TITLE
Introduction of "Reincarnation" genre on Kissmanga

### DIFF
--- a/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
+++ b/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
@@ -213,7 +213,9 @@ class Kissmanga : ParsedHttpSource() {
             Genre("Smut"),
             Genre("Sports"),
             Genre("Supernatural"),
+            Genre("Time Travel"),
             Genre("Tragedy"),
+            Genre("Transported"),
             Genre("Webtoon"),
             Genre("Yaoi"),
             Genre("Yuri")

--- a/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
+++ b/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
@@ -199,6 +199,7 @@ class Kissmanga : ParsedHttpSource() {
             Genre("Mystery"),
             Genre("One shot"),
             Genre("Psychological"),
+            Genre("Reincarnation"),
             Genre("Romance"),
             Genre("School Life"),
             Genre("Sci-fi"),


### PR DESCRIPTION
Should fix the indexing issue after the Romance genre in filters.

This issue started with the "Romance" genre and continued until the end. Everything before that seems okay. It's due to Kissmanga adding a Reincarnation genre. 

ex.
Select Seinen and you get Sci-fi.
Supernatural = Sports.
 
Tachiyomi(dev) - v0.6.3-1266 (fdroid)
en.Kissmanga - v1.0.2