### PR TITLE
Fix crash when downloading manga from Readmangatoday

### DIFF
--- a/src/en/readmangatoday/build.gradle
+++ b/src/en/readmangatoday/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: ReadMangaToday'
     pkgNameSuffix = "en.readmangatoday"
     extClass = '.Readmangatoday'
-    extVersionCode = 1
-    extVersionSuffix = 1
+    extVersionCode = 2
+    extVersionSuffix = 2
     libVersion = '1.0'
 }
 

--- a/src/en/readmangatoday/src/eu/kanade/tachiyomi/extension/en/readmangatoday/Readmangatoday.kt
+++ b/src/en/readmangatoday/src/eu/kanade/tachiyomi/extension/en/readmangatoday/Readmangatoday.kt
@@ -161,7 +161,7 @@ class Readmangatoday : ParsedHttpSource() {
         return pages
     }
 
-    override fun imageUrlParse(document: Document) = document.select("img.img-responsive-2").first().attr("src")
+    override fun imageUrlParse(document: Document) = document.select("#chapter_img").first().attr("src")
 
     private class Status : Filter.TriState("Completed")
     private class Genre(name: String, val id: Int) : Filter.TriState(name)


### PR DESCRIPTION
Hello!

Readmangatoday recently updated their HTML. So I updated the selector for the images.

This PR closes #128