### PR TITLE
[mangafox] Updated base domain name

### DIFF
--- a/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/Mangafox.kt
+++ b/src/en/mangafox/src/eu/kanade/tachiyomi/extension/en/mangafox/Mangafox.kt
@@ -17,7 +17,7 @@ class Mangafox : ParsedHttpSource() {
 
     override val name = "Mangafox"
 
-    override val baseUrl = "http://mangafox.me"
+    override val baseUrl = "http://mangafox.la"
 
     override val lang = "en"
 


### PR DESCRIPTION
mangafox updated their domain name. This caused images and manga not to load correctly.