### PR TITLE
MangaPark fixes

### DIFF
--- a/src/en/mangapark/build.gradle
+++ b/src/en/mangapark/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: MangaPark'
     pkgNameSuffix = "en.mangapark"
     extClass = '.MangaPark'
-    extVersionCode = 2
-    extVersionSuffix = 2
+    extVersionCode = 3
+    extVersionSuffix = 3
     libVersion = '1.0'
 }
 

--- a/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
+++ b/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
@@ -40,7 +40,6 @@ class MangaPark : ParsedHttpSource() {
 
         title = coverElement.attr("title")
 
-        thumbnail_url = cleanUrl(coverElement.getElementsByTag("img").attr("src"))
     }
 
     override fun popularMangaFromElement(element: Element) = mangaFromElement(element)

--- a/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
+++ b/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
@@ -106,14 +106,17 @@ class MangaPark : ParsedHttpSource() {
     override fun latestUpdatesRequest(page: Int) = GET("$baseUrl$directoryUrl/$page?latest")
 
     //TODO MangaPark has "versioning"
-    //TODO Currently we just use the version that is expanded by default
+    //TODO Previously we just use the version that is expanded by default however this caused an issue when a manga didnt have an expanded version
+    //TODO if we just choose one to expand it will cause potential missing chapters
+    //TODO right now all versions are combined so no chapters are missed
     //TODO Maybe make it possible for users to view the other versions as well?
-    override fun chapterListSelector() = ".stream:not(.collapsed) .volume .chapter li"
+    override fun chapterListSelector() = ".stream .volume .chapter li"
+
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         url = element.select("em > a").last().attr("href")
 
-        name = element.getElementsByClass("ch").text()
+        name = element.select("li span").first().text()
 
         date_upload = parseDate(element.getElementsByTag("i").text().trim())
     }


### PR DESCRIPTION
1. Fix low quality covers when browsing
2.  Adjust chapter names to include the title
3. Pull from all versions instead of expanded.  This prevents manga from not showing chapters cause there is no default expanded.  Also shows all chapters including duplicates compared to previously only showing what was in the expanded. I originally wrote to choose the last non expanded but upon looking into mangapark more some versions have more chapters then others and it wasnt consistent.  Easiest solution is to show them all similar to  how batoto had duplicates when more then one scanlator was working on it.

Cover change:
Old
<img src="https://user-images.githubusercontent.com/2092019/35512310-54357afe-04cd-11e8-985b-9b9274c9d79a.png" width="400">
Would update after clicking a manga
<img src="https://user-images.githubusercontent.com/2092019/35512292-44e62954-04cd-11e8-8669-2c8ca4c5b511.png" width="400">
New
<img src="https://user-images.githubusercontent.com/2092019/35512442-d157ac96-04cd-11e8-86bc-7eb65f7e86ef.png" width="400">

@null-dev as an FYI dont set the url in the mangaFromElement method, everything that shows on screen calls the mangadetailsparse and they usually have higher quaility images.  Its take a few seconds longer to show covers initially but works out better
