### PR TITLE
remove name from manga url to keep backwards compat

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = "all.mangadex"
     extClass = '.MangadexFactory'
-    extVersionCode = 5
-    extVersionSuffix = 5
+    extVersionCode = 6
+    extVersionSuffix = 6
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -60,17 +60,19 @@ open class Mangadex(override val lang: String, private val internalLang: String,
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
         element.select("a[href*=manga]").first().let {
-            manga.setUrlWithoutDomain(it.attr("href"))
+            manga.setUrlWithoutDomain(removeMangaNameFromUrl(it.attr("href")))
             manga.title = it.text().trim()
             manga.author = it?.text()?.trim()
         }
         return manga
     }
 
+    private fun removeMangaNameFromUrl(url: String): String = url.substringBeforeLast("/") + "/"
+
     override fun latestUpdatesFromElement(element: Element): SManga {
         val manga = SManga.create()
         element.let {
-            manga.setUrlWithoutDomain(it.attr("href"))
+            manga.setUrlWithoutDomain(removeMangaNameFromUrl(it.attr("href")))
             manga.title = it.text().trim()
         }
         return manga


### PR DESCRIPTION
Mangadex switched to adding the manga title at the end of the url.  This remove it back to just id so manga in library are shown as in library when searching the source.