### PR TITLE
mangadex: add more languages and isekai genre

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = "all.mangadex"
     extClass = '.MangadexFactory'
-    extVersionCode = 21
-    extVersionSuffix = 21
+    extVersionCode = 22
+    extVersionSuffix = 22
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -367,7 +367,8 @@ open class Mangadex(override val lang: String, private val internalLang: String,
             Genre("37", "Yaoi"),
             Genre("38", "Yuri"),
             Genre("39", "[no chapters]"),
-            Genre("40", "Game")
+            Genre("40", "Game"),
+            Genre("41", "Isekai")
     )
 
     companion object {

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangadexLanguages.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangadexLanguages.kt
@@ -20,6 +20,11 @@ class MangaDexCatalan : Mangadex("ca", "ct", 33)
 class MangaDexHungarian : Mangadex("hu", "hu", 9)
 class MangaDexBulgarian : Mangadex("bg", "bg", 14)
 class MangaDexFilipino : Mangadex("fil", "ph", 34)
+class MangaDexDutch : Mangadex("nl", "nl", 5)
+class MangaDexArabic : Mangadex("ar", "sa", 19)
+class MangaDexChineseSimp : Mangadex("zh-Hans", "cn", 21)
+class MangaDexChineseTrad : Mangadex("zh-Hant", "hk", 35)
+class MangaDexThai: Mangadex("th", "th", 32)
 
 fun getAllMangaDexLanguages() = listOf(
         MangaDexEnglish(),
@@ -38,5 +43,10 @@ fun getAllMangaDexLanguages() = listOf(
         MangaDexCatalan(),
         MangaDexHungarian(),
         MangaDexBulgarian(),
-        MangaDexFilipino()
+        MangaDexFilipino(),
+        MangaDexDutch(),
+        MangaDexArabic(),
+        MangaDexChineseSimp(),
+        MangaDexChineseTrad(),
+        MangaDexThai()
 )


### PR DESCRIPTION
I added the languages for which I believe there is some uploaded content.
On MangaDex there are other selectable languages:

1 | 1 | 1
-- | -- | --
2 | jp | Japanese
4 | rs | Serbo-Croatian
11 | fi | Finnish
13 | gr | Greek
17 | pt | Portuguese (Pt)
20 | dk | Danish
22 | bd | Bengali
23 | ro | Romanian
24 | cz | Czech
25 | mn | Mongolian
28 | kr | Korean
30 | ir | Persian
31 | my | Malaysian
36 | ua | Ukrainian

A note: the [Dmzj](https://github.com/inorichi/tachiyomi-extensions/blob/master/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt), [NHentai](https://github.com/inorichi/tachiyomi-extensions/blob/7929a768c4cb65536c852e81daf2e52432247700/src/all/nhentai/src/eu/kanade/tachiyomi/extension/all/nhentai/NHLangs.kt) and [E-Hentai](https://github.com/inorichi/tachiyomi-extensions/blob/7929a768c4cb65536c852e81daf2e52432247700/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHLangs.kt) extensions do not specify if the language is Simplified Chinese or Traditional Chinese. If we want to keep the same language codes here, Simplified Chinese (zh-Hans) could be replaced with generic Chinese (zh).