### PR TITLE
Add AkaiYuhiMun team to FoolSlide

### DIFF
--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: FoolSlide'
     pkgNameSuffix = "all.foolslide"
     extClass = '.FoolSlideFactory'
-    extVersionCode = 5
-    extVersionSuffix = 5
+    extVersionCode = 6
+    extVersionSuffix = 6
     libVersion = '1.2'
 }
 dependencies {

--- a/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlideFactory.kt
+++ b/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlideFactory.kt
@@ -49,7 +49,8 @@ fun getAllFoolSlide(): List<Source> {
         Russification(),
         NieznaniReader(),
         EvilFlowers(),
-        NaniScans()
+        NaniScans(),
+        AkaiYuhiMunTeam()
     )
 }
 
@@ -176,3 +177,5 @@ class NieznaniReader : FoolSlide("Nieznani", "http://reader.nieznani.mynindo.pl"
 class EvilFlowers : FoolSlide("Evil Flowers", "http://reader.evilflowers.com", "en")
 
 class NaniScans : FoolSlide("NANI? SCANS", "https://reader.naniscans.xyz", "en")
+
+class AkaiYuhiMunTeam : FoolSlide("AkaiYuhiMun team", "https://akaiyuhimun.ru", "ru", "/manga")


### PR DESCRIPTION
AkaiYuhiMun was removed in #322 from the MyMangaReader CMS extension as they no longer use a MyMangaReader CMS reader. Instead, since they now use FoolSlide, it is being moved to the FoolSlide extension.

Thanks to @Taumer for discovering this!