### PR TITLE
[FoolSlide/WpManga] Set time to midnight for 'today' and 'yesterday' date handling

### DIFF
--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: FoolSlide'
     pkgNameSuffix = "all.foolslide"
     extClass = '.FoolSlideFactory'
-    extVersionCode = 7
-    extVersionSuffix = 7
+    extVersionCode = 8
+    extVersionSuffix = 8
     libVersion = '1.2'
 }
 dependencies {

--- a/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlide.kt
+++ b/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlide.kt
@@ -143,13 +143,21 @@ open class FoolSlide(override val name: String, override val baseUrl: String, ov
         if (lcDate.endsWith(" ago"))
             parseRelativeDate(lcDate)?.let { return it }
 
-        //Handle 'yesterday' and 'today'
+        //Handle 'yesterday' and 'today', using midnight
         var relativeDate: Calendar? = null
         if (lcDate.startsWith("yesterday")) {
             relativeDate = Calendar.getInstance()
             relativeDate.add(Calendar.DAY_OF_MONTH, -1) //yesterday
+            relativeDate.set(Calendar.HOUR_OF_DAY, 0)
+            relativeDate.set(Calendar.MINUTE, 0)
+            relativeDate.set(Calendar.SECOND, 0)
+            relativeDate.set(Calendar.MILLISECOND, 0)
         } else if (lcDate.startsWith("today")) {
             relativeDate = Calendar.getInstance()
+            relativeDate.set(Calendar.HOUR_OF_DAY, 0)
+            relativeDate.set(Calendar.MINUTE, 0)
+            relativeDate.set(Calendar.SECOND, 0)
+            relativeDate.set(Calendar.MILLISECOND, 0)
         }
 
         relativeDate?.timeInMillis?.let {

--- a/src/all/wpmanga/build.gradle
+++ b/src/all/wpmanga/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: WPManga (Many sources)'
     pkgNameSuffix = "all.wpmanga"
     extClass = '.WpMangaFactory'
-    extVersionCode = 1
-    extVersionSuffix = 1
+    extVersionCode = 2
+    extVersionSuffix = 2
     libVersion = '1.2'
 }
 dependencies {

--- a/src/all/wpmanga/src/eu/kanade/tachiyomi/extension/all/wpmanga/WpManga.kt
+++ b/src/all/wpmanga/src/eu/kanade/tachiyomi/extension/all/wpmanga/WpManga.kt
@@ -108,13 +108,21 @@ open class WpManga(override val name: String, override val baseUrl: String, over
         if (lcDate.endsWith(" ago"))
             parseRelativeDate(lcDate)?.let { return it }
 
-        //Handle 'yesterday' and 'today'
+        //Handle 'yesterday' and 'today', using midnight
         var relativeDate: Calendar? = null
         if (lcDate.startsWith("yesterday")) {
             relativeDate = Calendar.getInstance()
             relativeDate.add(Calendar.DAY_OF_MONTH, -1) //yesterday
+            relativeDate.set(Calendar.HOUR_OF_DAY, 0)
+            relativeDate.set(Calendar.MINUTE, 0)
+            relativeDate.set(Calendar.SECOND, 0)
+            relativeDate.set(Calendar.MILLISECOND, 0)
         } else if (lcDate.startsWith("today")) {
             relativeDate = Calendar.getInstance()
+            relativeDate.set(Calendar.HOUR_OF_DAY, 0)
+            relativeDate.set(Calendar.MINUTE, 0)
+            relativeDate.set(Calendar.SECOND, 0)
+            relativeDate.set(Calendar.MILLISECOND, 0)
         }
 
         relativeDate?.timeInMillis?.let {


### PR DESCRIPTION
This is so that date_upload doesn't change on every refresh.

The use of Calendar.getInstance() in these causes the date_upload value for a chapter to change every time the source manga is refreshed, but only if that chapter's upload date was 'today' or 'yesterday'.
With the introduction of https://github.com/inorichi/tachiyomi/pull/1535, this would cause any manga with 'today' or 'yesterday' chapters to display as updated even if they were not updated.

One caveat to this is that if the same chapter is uploaded twice in a single day (with the same metadata), ChapterSourceSync.shouldUpdateDbChapter() won't be able to tell that the chapter has changed. However, this is consistent with the source's actual website, where the chapter would display "Today" for both uploads such that users wouldn't be able to tell if a chapter was reuploaded.