### PR TITLE
Replace any whitespace characters with spaces in query before searching

### DIFF
--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -40,6 +40,8 @@ open class Mangadex(override val lang: String, private val internalLang: String,
         Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
     }
 
+    private val whitespaceRegex = "\\s".toRegex()
+
     private fun clientBuilder(): OkHttpClient = clientBuilder(getShowR18())
 
 
@@ -162,7 +164,7 @@ open class Mangadex(override val lang: String, private val internalLang: String,
             }
         }
         //do traditional search
-        val url = HttpUrl.parse("$baseUrl/?page=search")!!.newBuilder().addQueryParameter("p", page.toString()).addQueryParameter("title", query)
+        val url = HttpUrl.parse("$baseUrl/?page=search")!!.newBuilder().addQueryParameter("p", page.toString()).addQueryParameter("title", query.replace(whitespaceRegex, " "))
         filters.forEach { filter ->
             when (filter) {
                 is TextField -> url.addQueryParameter(filter.key, filter.state)


### PR DESCRIPTION
I noticed that when copying/pasting text from websites into the catalog search, the MangaDex extension would sometimes come back with empty search results. The cause appears to be due to other whitespace characters (e.g. tab and newline) not being stripped before sending the API request. I've attached some GIFs to hopefully better show what I mean.
#### Current Behavior
![Current Behavior](https://user-images.githubusercontent.com/1396231/42924144-af34f95c-8add-11e8-908f-4e19c0c1141b.gif)

#### With Fix
![With Fix](https://user-images.githubusercontent.com/1396231/42924152-b7fa4efc-8add-11e8-8871-0f95e8a74595.gif)




