### PR TITLE
Fixed mangas descriptions on JapScan

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: Japscan'
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
-    extVersionCode = 2
-    extVersionSuffix = 1
+    extVersionCode = 3
+    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -83,8 +83,8 @@ class Japscan : ParsedHttpSource() {
         manga.author = rowElement.select("div:eq(0)").first()?.text()
         manga.artist = rowElement.select("div:eq(0)").first()?.text()
         manga.genre = rowElement.select("div:eq(2)").first()?.text()
-        manga.description = infoElement.select("div.synopsis").first()?.text()
-
+        manga.description = infoElement.select("div#synopsis").text()
+		
         manga.status = rowElement.select("div:eq(4)").first()?.text().orEmpty().let { parseStatus(it) }
 
         return manga


### PR DESCRIPTION
The mangas descriptions were all "unknown" in Tachiyomi. 
In JapScan's website, these descriptions were contained in the div with the id "synopsis", and not in the first div with a "synopsis" class.. This is now fixed and they do display correctly in the app