### PR TITLE
Dynasty-Scans: search results return page 1, only and infinitely

### DIFF
--- a/src/en/dynasty/build.gradle
+++ b/src/en/dynasty/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: Dynasty'
     pkgNameSuffix = 'en.dynasty'
     extClass = '.DynastyFactory'
-    extVersionCode = 7
-    extVersionSuffix = 7
+    extVersionCode = 8
+    extVersionSuffix = 8
     libVersion = '1.2'
 }
 

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyAnthologies.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyAnthologies.kt
@@ -13,7 +13,7 @@ class DynastyAnthologies : DynastyScans() {
     override fun popularMangaInitialUrl() = "$baseUrl/anthologies?view=cover"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/search?q=$query&classes%5B%5D=Anthology&sort=", headers)
+        return GET("$baseUrl/search?q=$query&classes%5B%5D=Anthology&sort=&page=$page", headers)
     }
 
     override fun mangaDetailsParse(document: Document): SManga {

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyChapters.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyChapters.kt
@@ -19,7 +19,7 @@ class DynastyChapters : DynastyScans() {
     private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Chapter&page=$page=$&sort="
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/search?q=$query&classes%5B%5D=Chapter&sort=", headers)
+        return GET("$baseUrl/search?q=$query&classes%5B%5D=Chapter&sort=&page=$page", headers)
     }
 
 

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyDoujins.kt
@@ -13,7 +13,7 @@ class DynastyDoujins : DynastyScans() {
     override fun popularMangaInitialUrl() = "$baseUrl/doujins?view=cover"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/search?q=$query&classes%5B%5D=Doujin&sort=", headers)
+        return GET("$baseUrl/search?q=$query&classes%5B%5D=Doujin&sort=&page=$page", headers)
     }
 
     override fun mangaDetailsParse(document: Document): SManga {

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyIssues.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyIssues.kt
@@ -13,7 +13,7 @@ class DynastyIssues : DynastyScans() {
     override fun popularMangaInitialUrl() = "$baseUrl/issues?view=cover"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/search?q=$query&classes%5B%5D=Issue&sort=", headers)
+        return GET("$baseUrl/search?q=$query&classes%5B%5D=Issue&sort=&page=$page", headers)
     }
 
     override fun mangaDetailsParse(document: Document): SManga {

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastySeries.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastySeries.kt
@@ -13,7 +13,7 @@ class DynastySeries : DynastyScans() {
     override fun popularMangaInitialUrl() = "$baseUrl/series?view=cover"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        return GET("$baseUrl/search?q=$query&classes%5B%5D=Series&sort=", headers)
+        return GET("$baseUrl/search?q=$query&classes%5B%5D=Series&sort=&page=$page", headers)
     }
 
     override fun mangaDetailsParse(document: Document): SManga {


### PR DESCRIPTION
Tachiyomi version: 0.7.4
Dynasty-Scans version: 1.2.7

For all 5 views of the Dynasty-Scans plugin, search results only return the first page of 20. You can continue to scroll and scroll and it will keep duplicating those results.

![loop](https://user-images.githubusercontent.com/1596835/46253906-99b6ef80-c454-11e8-9703-af4a46bb477c.png)

I checked the source and the search requests were missing the $page parameter. I added it to all 5 views and tested with the following queries:

Dynasty-Anthologies: `touhou`
Dynasty-Chapters: `touhou`
Dynasty-Doujins: `doujin`
Dynasty-Issues: `vol`
Dynasty-Series: `touhou`