### PR TITLE
[Mangadex] Remove erroneous manga.author from searchMangaFromElement()

### DIFF
--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -210,7 +210,6 @@ open class Mangadex(override val lang: String, private val internalLang: String,
             val url = modifyMangaUrl(it.attr("href"))
             manga.setUrlWithoutDomain(url)
             manga.title = it.text().trim()
-            manga.author = it?.text()?.trim()
         }
         return manga
     }


### PR DESCRIPTION
I didn't feel this warrant a full extension version bump, it can just get included with the next change to MD.