### PR TITLE
webtoons: handle multiple genres

### DIFF
--- a/src/en/webtoons/build.gradle
+++ b/src/en/webtoons/build.gradle
@@ -5,8 +5,8 @@ ext {
     appName = 'Tachiyomi: Webtoons'
     pkgNameSuffix = 'en.webtoons'
     extClass = '.Webtoons'
-    extVersionCode = 4
-    extVersionSuffix = 3
+    extVersionCode = 5
+    extVersionSuffix = 4
     libVersion = '1.2'
 }
 

--- a/src/en/webtoons/src/eu/kanade/tachiyomi/extension/en/webtoons/Webtoons.kt
+++ b/src/en/webtoons/src/eu/kanade/tachiyomi/extension/en/webtoons/Webtoons.kt
@@ -122,7 +122,7 @@ class Webtoons : ParsedHttpSource() {
         val manga = SManga.create()
         manga.author = detailElement.select(".author:nth-of-type(1)").text().substringBefore("author info")
         manga.artist = detailElement.select(".author:nth-of-type(2)").first()?.text()?.substringBefore("author info") ?: manga.author
-        manga.genre = detailElement.select(".genre").text()
+        manga.genre = detailElement.select(".genre").map { it.text() }.joinToString(", ")
         manga.description = infoElement.select("p.summary").text()
         manga.status = infoElement.select("p.day_info").text().orEmpty().let { parseStatus(it) }
         manga.thumbnail_url = discoverPic.select("img").not("[alt=Representative image").first()?.attr("src") ?: picElement.attr("style")?.substringAfter("url(")?.substringBeforeLast(")")


### PR DESCRIPTION
Currently, multiple genres are combined into one with no separation.
![screenshot_1539922926](https://user-images.githubusercontent.com/9275775/47197594-133b5280-d31c-11e8-94d2-35ae951787d7.png)

This fixes that.
![screenshot_1539923000](https://user-images.githubusercontent.com/9275775/47197595-16364300-d31c-11e8-8050-b3339f261268.png)
