### PR TITLE
Fixes TuMangaOnline, #561

### DIFF
--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -5,9 +5,9 @@ ext {
     appName = 'Tachiyomi: TuMangaOnline'
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
-    extVersionCode = 1
+    extVersionCode = 2
     extVersionSuffix = 1
-    libVersion = '1.2.1'
+    libVersion = '1.2'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -6,7 +6,7 @@ ext {
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
     extVersionCode = 2
-    extVersionSuffix = 1
+    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -7,7 +7,7 @@ ext {
     extClass = '.TuMangaOnline'
     extVersionCode = 1
     extVersionSuffix = 1
-    libVersion = '1.2'
+    libVersion = '1.2.1'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -4,10 +4,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.HttpUrl
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.*
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -30,7 +27,10 @@ class TuMangaOnline : ParsedHttpSource() {
             .retryOnConnectionFailure(true)
             .followRedirects(true)
             .build()!!
-
+    override fun headersBuilder(): Headers.Builder {
+        return Headers.Builder()
+                .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; WOW64) Gecko/20100101 Firefox/60")
+    }
     private fun getBuilder(url: String): String {
         val req = Request.Builder()
                 .addHeader("User-Agent", "Mozilla/5.0 (Windows NT 10.0; WOW64) Gecko/20100101 Firefox/60")
@@ -196,7 +196,7 @@ class TuMangaOnline : ParsedHttpSource() {
         val url = getBuilder(baseUrl + chapter.url)
 
         // Get /cascade instead of /paginate to get all pages at once
-        return GET(url.substringBeforeLast("/") + "/cascade")
+        return GET(url.substringBeforeLast("/") + "/cascade", headers)
     }
 
     override fun pageListParse(document: Document): List<Page> = mutableListOf<Page>().apply {


### PR DESCRIPTION
Fixes #561.

Overriding headersBuilder and adding headers to the GET request.

Reopened because I forgot to change the extension version.