### PR TITLE
Remove extVersionSuffix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ Before you start, please note that the ability to use following technologies is 
 
 ## Writing an extension
 
-The quickest way to get started is to copy an existing extension's folder structure and renaming it as needed. Of course, that also means that there's plenty of existing extensions that you can reference as you go! 
+The quickest way to get started is to copy an existing extension's folder structure and renaming it as needed. Of course, that also means that there's plenty of existing extensions that you can reference as you go!
 
 Make sure that your new extension's `build.gradle` file follows the following structure:
 
@@ -23,7 +23,6 @@ ext {
     pkgNameSuffix = 'lang.mycatalogue'
     extClass = '.MyCatalogue'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 
@@ -35,9 +34,10 @@ apply from: "$rootDir/common.gradle"
 | `appName` | The name of the Android application. By prefixing it with `Tachiyomi: `, it will be easier to locate with an Android package manager. |
 | `pkgNameSuffix` | A unique suffic added to `eu.kanade.tachiyomi.extension`. The language and the site name should be enough. Remember your catalogue code implementation must be placed in this package. |
 | `extClass` | Points to the catalogue class. You can use a relative path starting with a dot (the package name is the base path). This is required for Tachiyomi to instantiate the catalogue. |
-| `extVersionCode` | The version code of the catalogue. This must be increased with any change to the implementation. |
-| `extVersionSuffix` | The last part of the versioning. |
-| `libVersion` | The version of the [extensions library](https://github.com/inorichi/tachiyomi-extensions-lib)* used. When this value is changed, `extVersionSuffix` should be reset to `1`. With the example used above, the version of the catalogue would be `1.2.1`. |
+| `extVersionCode` | The version code of the catalogue. This must be increased with any change to the implementation and cannot be `0`. |
+| `libVersion` | The version of the [extensions library](https://github.com/inorichi/tachiyomi-extensions-lib)* used. |
+
+The catalogue's version name is based off of `libVersion` and `extVersionCode`. With the example used above, the version of the catalogue would be `1.2.1`.
 
 \* Note: this library only contains the method definitions so that the compiler can resolve them. The actual implementation is written in Tachiyomi.
 

--- a/common.gradle
+++ b/common.gradle
@@ -31,7 +31,7 @@ android {
         targetSdkVersion 27
         applicationIdSuffix pkgNameSuffix
         versionCode extVersionCode
-        versionName "$libVersion.$extVersionSuffix"
+        versionName "$libVersion.$extVersionCode"
         setProperty("archivesBaseName", "tachiyomi-$pkgNameSuffix-v$versionName")
         manifestPlaceholders = [
                 appName: appName,

--- a/src/all/ehentai/build.gradle
+++ b/src/all/ehentai/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'all.ehentai'
     extClass = '.EHJapanese; .EHEnglish; .EHChinese; .EHDutch; .EHFrench; .EHGerman; .EHHungarian; .EHItalian; .EHKorean; .EHPolish; .EHPolish; .EHPortuguese; .EHRussian; .EHSpanish; .EHThai; .EHVietnamese; .EHSpeechless; .EHOther'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = "all.foolslide"
     extClass = '.FoolSlideFactory'
     extVersionCode = 8
-    extVersionSuffix = 8
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
     extVersionCode = 40
-    extVersionSuffix = 40
     libVersion = '1.2'
 }
 

--- a/src/all/mmrcms/build.gradle
+++ b/src/all/mmrcms/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'all.mmrcms'
     extClass = '.MyMangaReaderCMSSources'
     extVersionCode = 12
-    extVersionSuffix = 12
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
     extVersionCode = 12
-    extVersionSuffix = 11
     libVersion = '1.2'
 }
 

--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'all.nhentai'
     extClass = '.NHJapanese; .NHEnglish; .NHChinese; .NHSpeechless; .NHCzech; .NHEsperanto; .NHMongolian; .NHSlovak; .NHArabic; .NHUkrainian'
     extVersionCode = 2
-    extVersionSuffix = 0
     libVersion = '1.2'
 }
 

--- a/src/all/wpmanga/build.gradle
+++ b/src/all/wpmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'all.wpmanga'
     extClass = '.WpMangaFactory'
     extVersionCode = 3
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/de/wiemanga/build.gradle
+++ b/src/de/wiemanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'de.wiemanga'
     extClass = '.WieManga'
     extVersionCode = 2
-    extVersionSuffix = 0
     libVersion = '1.2'
 }
 

--- a/src/en/dynasty/build.gradle
+++ b/src/en/dynasty/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.dynasty'
     extClass = '.DynastyFactory'
     extVersionCode = 8
-    extVersionSuffix = 8
     libVersion = '1.2'
 }
 

--- a/src/en/hentai2read/build.gradle
+++ b/src/en/hentai2read/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.hentai2read'
     extClass = '.Hentai2Read'
     extVersionCode = 3
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/en/kissmanga/build.gradle
+++ b/src/en/kissmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.kissmanga'
     extClass = '.Kissmanga'
     extVersionCode = 8
-    extVersionSuffix = 5
     libVersion = '1.2'
 }
 

--- a/src/en/mangacow/build.gradle
+++ b/src/en/mangacow/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangacow'
     extClass = '.Mangacow'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/en/mangaeden/build.gradle
+++ b/src/en/mangaeden/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangaeden'
     extClass = '.Mangaeden'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/en/mangafox/build.gradle
+++ b/src/en/mangafox/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangafox'
     extClass = '.Mangafox'
     extVersionCode = 3
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/en/mangafree/build.gradle
+++ b/src/en/mangafree/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangafree'
     extClass = '.Mangafree'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangago/build.gradle
+++ b/src/en/mangago/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangago'
     extClass = '.Mangago'
     extVersionCode = 6
-    extVersionSuffix = 5
     libVersion = '1.2'
 }
 

--- a/src/en/mangahasu/build.gradle
+++ b/src/en/mangahasu/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangahasu'
     extClass = '.Mangahasu'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangahere/build.gradle
+++ b/src/en/mangahere/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangahere'
     extClass = '.Mangahere'
     extVersionCode = 6
-    extVersionSuffix = 4
     libVersion = '1.2'
 }
 

--- a/src/en/mangakakalot/build.gradle
+++ b/src/en/mangakakalot/build.gradle
@@ -5,8 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaKakalot'
     pkgNameSuffix = 'en.mangakakalot'
     extClass = '.Mangakakalot'
-    extVersionCode = 1
-    extVersionSuffix = 2
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/manganelo/build.gradle
+++ b/src/en/manganelo/build.gradle
@@ -5,8 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaNelo'
     pkgNameSuffix = 'en.manganelo'
     extClass = '.Manganelo'
-    extVersionCode = 1
-    extVersionSuffix = 2
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangapark/build.gradle
+++ b/src/en/mangapark/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangapark'
     extClass = '.MangaPark'
     extVersionCode = 3
-    extVersionSuffix = 3
     libVersion = '1.0'
 }
 

--- a/src/en/mangarock/build.gradle
+++ b/src/en/mangarock/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangarock'
     extClass = '.MangaRock'
     extVersionCode = 3
-    extVersionSuffix = 2
     libVersion = '1.0'
 }
 

--- a/src/en/mangasee/build.gradle
+++ b/src/en/mangasee/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangasee'
     extClass = '.Mangasee'
     extVersionCode = 4
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangastream/build.gradle
+++ b/src/en/mangastream/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangastream'
     extClass = '.Mangastream'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.0'
 }
 

--- a/src/en/mangazuki/build.gradle
+++ b/src/en/mangazuki/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.mangazuki'
     extClass = '.Mangazuki'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.0'
 }
 

--- a/src/en/merakiscans/build.gradle
+++ b/src/en/merakiscans/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.merakiscans'
     extClass = '.MerakiScans'
     extVersionCode = 2
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/en/perveden/build.gradle
+++ b/src/en/perveden/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.perveden'
     extClass = '.Perveden'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/en/readcomiconline/build.gradle
+++ b/src/en/readcomiconline/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.readcomiconline'
     extClass = '.Readcomiconline'
     extVersionCode = 4
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/en/readcomictv/build.gradle
+++ b/src/en/readcomictv/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.readcomictv'
     extClass = '.Readcomictv'
     extVersionCode = 3
-    extVersionSuffix = 3
     libVersion = '1.0'
 }
 

--- a/src/en/readmangatoday/build.gradle
+++ b/src/en/readmangatoday/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.readmangatoday'
     extClass = '.Readmangatoday'
     extVersionCode = 5
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/en/shoujosense/build.gradle
+++ b/src/en/shoujosense/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.shoujosense'
     extClass = '.ShoujoSense'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/en/tapastic/build.gradle
+++ b/src/en/tapastic/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.tapastic'
     extClass = '.Tapastic'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/en/webtoons/build.gradle
+++ b/src/en/webtoons/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.webtoons'
     extClass = '.Webtoons'
     extVersionCode = 5
-    extVersionSuffix = 4
     libVersion = '1.2'
 }
 

--- a/src/en/xkcd/build.gradle
+++ b/src/en/xkcd/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'en.xkcd'
     extClass = '.Xkcd'
     extVersionCode = 4
-    extVersionSuffix = 4
     libVersion = '1.2'
 }
 

--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
     extVersionCode = 3
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/it/hentaifantasy/build.gradle
+++ b/src/it/hentaifantasy/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'it.hentaifantasy'
     extClass = '.HentaiFantasy'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/it/mangaeden/build.gradle
+++ b/src/it/mangaeden/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'it.mangaeden'
     extClass = '.Mangaeden'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/it/perveden/build.gradle
+++ b/src/it/perveden/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'it.perveden'
     extClass = '.Perveden'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.0'
 }
 

--- a/src/ja/rawQQ/build.gradle
+++ b/src/ja/rawQQ/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ja.rawqq'
     extClass = '.Rawqq'
     extVersionCode = 2
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/ja/rawlh/build.gradle
+++ b/src/ja/rawlh/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ja.rawlh'
     extClass = '.Rawlh'
     extVersionCode = 5
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/ja/senmanga/build.gradle
+++ b/src/ja/senmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ja.senmanga'
     extClass = '.SenManga'
     extVersionCode = 2
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/pt/mangasproject/build.gradle
+++ b/src/pt/mangasproject/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'pt.mangasproject'
     extClass = '.MangasProject'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/pt/unionmangas/build.gradle
+++ b/src/pt/unionmangas/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'pt.unionmangas'
     extClass = '.UnionMangas'
     extVersionCode = 3
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/ru/comx/build.gradle
+++ b/src/ru/comx/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.comx'
     extClass = '.ComX'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/ru/desu/build.gradle
+++ b/src/ru/desu/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.desu'
     extClass = '.Desu'
     extVersionCode = 4
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/ru/libmanga/build.gradle
+++ b/src/ru/libmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.libmanga'
     extClass = '.LibMangaFactory'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/ru/mangachan/build.gradle
+++ b/src/ru/mangachan/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.mangachan'
     extClass = '.Mangachan'
     extVersionCode = 6
-    extVersionSuffix = 6
     libVersion = '1.2'
 }
 

--- a/src/ru/mangahub/build.gradle
+++ b/src/ru/mangahub/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.mangahub'
     extClass = '.Mangahub'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/ru/mintmanga/build.gradle
+++ b/src/ru/mintmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.mintmanga'
     extClass = '.Mintmanga'
     extVersionCode = 8
-    extVersionSuffix = 8
     libVersion = '1.2'
 }
 

--- a/src/ru/onlinecomics/build.gradle
+++ b/src/ru/onlinecomics/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.onlinecomics'
     extClass = '.Onlinecomics'
     extVersionCode = 1
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/ru/readmanga/build.gradle
+++ b/src/ru/readmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.readmanga'
     extClass = '.Readmanga'
     extVersionCode = 8
-    extVersionSuffix = 8
     libVersion = '1.2'
 }
 

--- a/src/ru/selfmanga/build.gradle
+++ b/src/ru/selfmanga/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'ru.selfmanga'
     extClass = '.Selfmanga'
     extVersionCode = 2
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/vi/academyvn/build.gradle
+++ b/src/vi/academyvn/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'vi.academyvn'
     extClass = '.Academyvn'
     extVersionCode = 3
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/vi/blogtruyen/build.gradle
+++ b/src/vi/blogtruyen/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'vi.blogtruyen'
     extClass = '.Blogtruyen'
     extVersionCode = 2
-    extVersionSuffix = 1
     libVersion = '1.2'
 }
 

--- a/src/vi/iutruyentranh/build.gradle
+++ b/src/vi/iutruyentranh/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'vi.iutruyentranh'
     extClass = '.Iutruyentranh'
     extVersionCode = 3
-    extVersionSuffix = 2
     libVersion = '1.2'
 }
 

--- a/src/vi/truyentranhlh/build.gradle
+++ b/src/vi/truyentranhlh/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'vi.truyentranhlh'
     extClass = '.Truyentranhlh'
     extVersionCode = 4
-    extVersionSuffix = 3
     libVersion = '1.2'
 }
 

--- a/src/zh/dmzj/build.gradle
+++ b/src/zh/dmzj/build.gradle
@@ -6,7 +6,6 @@ ext {
     pkgNameSuffix = 'zh.dmzj'
     extClass = '.Dmzj'
     extVersionCode = 4
-    extVersionSuffix = 4
     libVersion = '1.0'
 }
 


### PR DESCRIPTION
There isn't much value in having `extVersionSuffix` for the version name since just incrementing the `extVersionCode` can ensure unique names already. Instead, having both just seems to confuse developers.