### PR TITLE
Add Latest Updates to Dynasty-Chapters

### DIFF
--- a/src/en/dynasty/build.gradle
+++ b/src/en/dynasty/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Dynasty'
     pkgNameSuffix = 'en.dynasty'
     extClass = '.DynastyFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyChapters.kt
+++ b/src/en/dynasty/src/eu/kanade/tachiyomi/extension/en/dynasty/DynastyChapters.kt
@@ -17,11 +17,13 @@ class DynastyChapters : DynastyScans() {
     override fun popularMangaInitialUrl() = ""
 
     private fun popularMangaInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Chapter&page=$page=$&sort="
+    private fun latestUpdatesInitialUrl(page: Int) = "$baseUrl/search?q=&classes%5B%5D=Chapter&page=$page=$&sort=created_at"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         return GET("$baseUrl/search?q=$query&classes%5B%5D=Chapter&sort=&page=$page", headers)
     }
 
+    override val supportsLatest = true
 
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
@@ -79,12 +81,20 @@ class DynastyChapters : DynastyScans() {
         return GET(popularMangaInitialUrl(page), headers)
     }
 
+    override fun latestUpdatesRequest(page: Int): Request {
+        return GET(latestUpdatesInitialUrl(page), headers)
+    }
+
     override fun popularMangaNextPageSelector() = searchMangaNextPageSelector()
+    override fun latestUpdatesNextPageSelector() = searchMangaNextPageSelector()
 
     override fun popularMangaSelector() = searchMangaSelector()
+    override fun latestUpdatesSelector() = searchMangaSelector()
 
     override fun popularMangaFromElement(element: Element) = searchMangaFromElement(element)
+    override fun latestUpdatesFromElement(element: Element) = searchMangaFromElement(element)
 
     override fun popularMangaParse(response: Response) = searchMangaParse(response)
+    override fun latestUpdatesParse(response: Response) = searchMangaParse(response)
 
 }


### PR DESCRIPTION
The Dynasty website does support sorting by date added for all the other classes as well, but the results don't seem to make much sense (might be using the started date instead of updated?), so I only added this for chapters.