### PR TITLE
Fixes MyReadingManga downloads and selector

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -165,7 +165,7 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         val pages = mutableListOf<Page>()
         val elements = body.select(".separator [data-lazyloaded='1']")
         for (i in 0 until elements.size) {
-            pages.add(Page(1, "", getImage(elements[i])))
+            pages.add(Page(i, "", getImage(elements[i])))
         }
         return pages
     }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -163,7 +163,7 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val body = response.asJsoup()
         val pages = mutableListOf<Page>()
-        val elements = body.select(".entry-content>*>img")
+        val elements = body.select(".separator [data-lazyloaded='1']")
         for (i in 0 until elements.size) {
             pages.add(Page(1, "", getImage(elements[i])))
         }


### PR DESCRIPTION
Fixes #577 
The Page parser was setting 1 as index on every page, making it impossible to download, also the selector was not totally correct, since some mangas randomly have a different html structure.