### PR TITLE
Fixes MyReadingManga selector and jpeg thumbnails

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 15
+    extVersionCode = 16
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -163,7 +163,7 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val body = response.asJsoup()
         val pages = mutableListOf<Page>()
-        val elements = body.select("[data-lazyloaded='1']:not([width='120']):not([data-original-width='300'])")
+        val elements = body.select("[data-original-width]:not([width='120']):not([data-original-width='300'])")
         for (i in 0 until elements.size) {
             pages.add(Page(i, "", getImage(elements[i])))
         }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -92,7 +92,7 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         var url =
                 when {
                     element.attr("data-src").endsWith(".jpg") || element.attr("data-src").endsWith(".png") || element.attr("data-src").endsWith(".jpeg") -> element.attr("data-src")
-                    element.attr("src").endsWith(".jpg") || element.attr("src").endsWith(".png") || element.attr("data-src").endsWith(".jpeg") -> element.attr("src")
+                    element.attr("src").endsWith(".jpg") || element.attr("src").endsWith(".png") || element.attr("src").endsWith(".jpeg") -> element.attr("src")
                     else -> element.attr("data-lazy-src")
                 }
         if (url.startsWith("//")) {


### PR DESCRIPTION
Hello and apologies in advanced as this is my first time using github, contributing to this project, and teaching myself enough code within the last few hours to patch some fixes. This pull should fix:

- "page list in empty" error (again). Instead of using the attribute [data-lazyloaded='1'] which I could not find (maybe due to an update on lazyloader), I switched it out to just [data-original-width] which is part of each page (leaving the exclusions)

- I noticed a few thumbnails were not loading. They were jpegs which was supposed to be fixed in a previous patch but one of the elements was a duplicate so I fixed it from element.attr("data-src") to element.attr("src") in the get image section. 

Hope this was helpful and can be accepted. 