### PR TITLE
Change mangakalot domain to manganelo.com

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Japscan'
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -23,7 +23,7 @@ class Japscan : ParsedHttpSource() {
 
     override val name = "Japscan"
 
-    override val baseUrl = "https://www.japscan.cc"
+    override val baseUrl = "https://www.japscan.to"
 
     override val lang = "fr"
 


### PR DESCRIPTION
Fixes manga like Nanatsu no Taizai which has a JS/noscript redirect on mangakalot to manganelo.

Bug reported on Discord.