### PR TITLE
Update UnionMangas with their new host

### DIFF
--- a/src/pt/unionmangas/build.gradle
+++ b/src/pt/unionmangas/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Union Mangás'
     pkgNameSuffix = 'pt.unionmangas'
     extClass = '.UnionMangas'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 

--- a/src/pt/unionmangas/src/eu/kanade/tachiyomi/extension/pt/unionmangas/UnionMangas.kt
+++ b/src/pt/unionmangas/src/eu/kanade/tachiyomi/extension/pt/unionmangas/UnionMangas.kt
@@ -21,7 +21,7 @@ class UnionMangas : ParsedHttpSource() {
 
     override val name = "Union Mangás"
 
-    override val baseUrl = "http://unionmangas.site"
+    override val baseUrl = "http://unionmangas.top"
 
     override val lang = "pt"
 
@@ -39,7 +39,7 @@ class UnionMangas : ParsedHttpSource() {
 
     private val catalogHeaders = Headers.Builder().apply {
         add("User-Agent", "Mozilla/5.0 (Windows NT 6.3; WOW64)")
-        add("Host", "unionmangas.site")
+        add("Host", "unionmangas.top")
         add("Referer", baseUrl)
     }.build()
 


### PR DESCRIPTION
Fixes the "HTTP error 403" when trying to access the catalogue.