### PR TITLE
MangaPlus: Add UUID header (fixes #833)

### DIFF
--- a/src/en/mangaplus/build.gradle
+++ b/src/en/mangaplus/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Manga Plus by Shueisha'
     pkgNameSuffix = 'en.mangaplus'
     extClass = '.MangaPlus'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangaplus/src/eu/kanade/tachiyomi/extension/en/mangaplus/MangaPlus.kt
+++ b/src/en/mangaplus/src/eu/kanade/tachiyomi/extension/en/mangaplus/MangaPlus.kt
@@ -11,6 +11,7 @@ import eu.kanade.tachiyomi.source.online.HttpSource
 import okhttp3.*
 import rx.Observable
 import java.lang.Exception
+import java.util.UUID.randomUUID
 
 class MangaPlus : HttpSource() {
     override val name = "Manga Plus by Shueisha"
@@ -25,7 +26,7 @@ class MangaPlus : HttpSource() {
         add("Origin", WEB_URL)
         add("Referer", WEB_URL)
         add("User-Agent", USER_AGENT)
-        add("X-Requested-With", "XMLHttpRequest")
+        add("SESSION-TOKEN", randomUUID().toString())
     }.build()
 
     override val client = network.client.newBuilder().addInterceptor {


### PR DESCRIPTION
`X-Requested-With` header no-longer appears in requests on the website