### PR TITLE
Implement Nosrob's Japscan Image Discrambler

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Japscan'
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
fix #847 
fix #698

Original code is written by @Nosrob,  See https://github.com/inorichi/tachiyomi-extensions/issues/698#issuecomment-467929831

I'm not sure what image is encrypted. (I'm not japscan user)
It seems uri contains `clel` when it is scrambled. (normal one is just `lel`)