### PR TITLE
Add pagination to MangaZuki (closes #835)

### DIFF
--- a/src/en/mangazuki/build.gradle
+++ b/src/en/mangazuki/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangazuki'
     pkgNameSuffix = 'en.mangazuki'
     extClass = '.Mangazuki'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.0'
 }
 


### PR DESCRIPTION
Doesn't address the issue of duplicate entries in the latest list that was present in the old version as well though.