### PR TITLE
mangadex: Add search by id

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 51
+    extVersionCode = 52
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Allows to search manga on Mangadex using their respective IDs and prefixing the search with "id:".