### PR TITLE
NHentai: update user agent, introduce artificial delay for fetching images (fixes #938)

### DIFF
--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: NHentai'
     pkgNameSuffix = 'all.nhentai'
     extClass = '.NHEnglish; .NHJapanese; .NHChinese'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
This probably isn't the best way of handling it, but it's the most rudimentary form of "throttling" I could think of within the constraint of an extension.

I'm open to suggestions.