### PR TITLE
Filter out "untranslated preview pictures" and RAWs from JapScan.

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Japscan'
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -159,7 +159,9 @@ class Japscan : ParsedHttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun chapterListSelector() = "div#chapters_list > div.collapse > div.chapters_list"
+    override fun chapterListSelector() = "div#chapters_list > div.collapse > div.chapters_list:not(:contains(spoiler spoiler))"
+    //JapScan uploads some useless "preview" chapters, containing untranslated pictures taken from a raw.
+    //Those are tagged as "spoiler SPOILER", so the selector makes sure to dismiss these from the chapter list.
 
     override fun chapterFromElement(element: Element): SChapter {
         val urlElement = element.select("a").first()

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -168,7 +168,8 @@ class Japscan : ParsedHttpSource() {
 
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
-        chapter.name = urlElement.text().replace(" VUS", "")
+        chapter.name = urlElement.ownText()
+        //Using ownText() so that the childs text (like "VUS" or "RAW" badges) isn't part of the chapter name.
         chapter.date_upload = element.select("> span").text().trim().let { parseChapterDate(it) }
         return chapter
     }

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -160,7 +160,7 @@ class Japscan : ParsedHttpSource() {
     }
 
     override fun chapterListSelector() = "#chapters_list > div.collapse > div.chapters_list"+
-            ":not(:has(.badge:contains(SPOILER),.badge:contains(RAW))"
+            ":not(:has(.badge:contains(SPOILER),.badge:contains(RAW)))"
     //JapScan sometimes uploads some "spoiler preview" chapters, containing 2 or 3 untranslated pictures taken from a raw. Sometimes they also upload full RAWs and replace it with a translation as soon as available.
     //Those have a span.badge "SPOILER" or "RAW". The additional pseudo selector makes sure to exclude these from the chapter list.
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -159,9 +159,11 @@ class Japscan : ParsedHttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun chapterListSelector() = "div#chapters_list > div.collapse > div.chapters_list:not(:contains(spoiler spoiler))"
-    //JapScan uploads some useless "preview" chapters, containing untranslated pictures taken from a raw.
-    //Those are tagged as "spoiler SPOILER", so the selector makes sure to dismiss these from the chapter list.
+    override fun chapterListSelector() = "#chapters_list > div.collapse > div.chapters_list"+
+            ":not(:has(.badge:contains(SPOILER),.badge:contains(RAW))"
+    //JapScan sometimes uploads some "spoiler preview" chapters, containing 2 or 3 untranslated pictures taken from a raw. Sometimes they also upload full RAWs and replace it with a translation as soon as available.
+    //Those have a span.badge "SPOILER" or "RAW". The additional pseudo selector makes sure to exclude these from the chapter list.
+
 
     override fun chapterFromElement(element: Element): SChapter {
         val urlElement = element.select("a").first()
@@ -169,7 +171,7 @@ class Japscan : ParsedHttpSource() {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain(urlElement.attr("href"))
         chapter.name = urlElement.ownText()
-        //Using ownText() so that the childs text (like "VUS" or "RAW" badges) isn't part of the chapter name.
+        //Using ownText() doesn't include childs' text, like "VUS" or "RAW" badges, in the chapter name.
         chapter.date_upload = element.select("> span").text().trim().let { parseChapterDate(it) }
         return chapter
     }

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -160,8 +160,8 @@ class Japscan : ParsedHttpSource() {
     }
 
     override fun chapterListSelector() = "#chapters_list > div.collapse > div.chapters_list"+
-            ":not(:has(.badge:contains(SPOILER),.badge:contains(RAW)))"
-    //JapScan sometimes uploads some "spoiler preview" chapters, containing 2 or 3 untranslated pictures taken from a raw. Sometimes they also upload full RAWs and replace it with a translation as soon as available.
+            ":not(:has(.badge:contains(SPOILER),.badge:contains(RAW),.badge:contains(VUS)))"
+    //JapScan sometimes uploads some "spoiler preview" chapters, containing 2 or 3 untranslated pictures taken from a raw. Sometimes they also upload full RAWs/US versions and replace them with a translation as soon as available.
     //Those have a span.badge "SPOILER" or "RAW". The additional pseudo selector makes sure to exclude these from the chapter list.
 
 


### PR DESCRIPTION
Changed the CSS selector to exclude chapter names  containing "Spoiler SPOILER" as described in
inorichi/tachiyomi#1925 

(would be great to somehow separate that feature request above and the issue described in it, to actually put that issue here instead.)

Still draft as I'm awaiting confirmation that these chapters are ALWAYS named "Spoiler SPOILER".