### PR TITLE
create mangadex.org intent filter to open mangadex urls with tachiyomi

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,11 @@
 buildscript {
-    ext.kotlin_version = '1.3.20'
+    ext.kotlin_version = '1.3.21'
     repositories {
         jcenter()
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.3.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/common.gradle
+++ b/common.gradle
@@ -20,9 +20,11 @@ android {
         }
         release {
             res.srcDirs = ['res']
+            manifest.srcFile "AndroidManifest.xml"
         }
         debug {
             res.srcDirs = ['res']
+            manifest.srcFile "AndroidManifest.xml"
         }
     }
 

--- a/src/all/mangadex/AndroidManifest.xml
+++ b/src/all/mangadex/AndroidManifest.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+
+        <activity
+            android:name="mangadex.MangadexUrlActivity"
+            android:theme="@android:style/Theme.NoDisplay"
+            android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="https"
+                    android:host="mangadex.org"
+                    android:pathPattern="/title/..*" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/src/all/mangadex/AndroidManifest.xml
+++ b/src/all/mangadex/AndroidManifest.xml
@@ -4,7 +4,7 @@
     <application>
 
         <activity
-            android:name="mangadex.MangadexUrlActivity"
+            android:name=".MangadexUrlActivity"
             android:theme="@android:style/Theme.NoDisplay"
             android:excludeFromRecents="true">
             <intent-filter>

--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 53
+    extVersionCode = 54
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangadexUrlActivity.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangadexUrlActivity.kt
@@ -1,8 +1,8 @@
-package mangadex
+package eu.kanade.tachiyomi.extension.all.mangadex
 
 import android.app.Activity
+import android.content.ActivityNotFoundException
 import android.content.Intent
-import android.net.Uri
 import android.os.Bundle
 import android.util.Log
 
@@ -22,14 +22,21 @@ class MangadexUrlActivity : Activity() {
         if (pathSegments != null && pathSegments.size > 1) {
             val titleid = pathSegments[1]
             val mainIntent = Intent().apply {
-                action = Intent.ACTION_VIEW
-                data = Uri.parse("tachiyomi://search/MangaDex/id:$titleid")
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", "id:$titleid")
+                putExtra("filter", packageName)
             }
-            Log.v("...", "opening $mainIntent")
-            startActivity(mainIntent)
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("MangadexUrlActivity", e.toString())
+            }
         } else {
-            Log.e("...", "could not parse uri from intent $intent")
+            Log.e("MangadexUrlActivity", "could not parse uri from intent $intent")
         }
+
         finish()
+        System.exit(0)
     }
 }

--- a/src/all/mangadex/src/mangadex/MangadexUrlActivity.kt
+++ b/src/all/mangadex/src/mangadex/MangadexUrlActivity.kt
@@ -1,0 +1,35 @@
+package mangadex
+
+import android.app.Activity
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.util.Log
+
+/**
+ * Springboard that accepts https://mangadex.com/title/xxx intents and redirects them to
+ * the main tachiyomi process. The idea is to not install the intent filter unless
+ * you have this extension installed, but still let the main tachiyomi app control
+ * things.
+ *
+ * Main goal was to make it easier to open manga in Tachiyomi in spite of the DDoS blocking
+ * the usual search screen from working.
+ */
+class MangadexUrlActivity : Activity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 1) {
+            val titleid = pathSegments[1]
+            val mainIntent = Intent().apply {
+                action = Intent.ACTION_VIEW
+                data = Uri.parse("tachiyomi://search/MangaDex/id:$titleid")
+            }
+            Log.v("...", "opening $mainIntent")
+            startActivity(mainIntent)
+        } else {
+            Log.e("...", "could not parse uri from intent $intent")
+        }
+        finish()
+    }
+}


### PR DESCRIPTION
Typing "id:xxx" in the searchbox due to the mangadex ddos is a drag. Here's a shortcut:
![](https://i.imgur.com/tGauyO4.png)

Second pr for supporting "tachiyomi://search" links: inorichi/tachiyomi#1936