### PR TITLE
Fix invalid selector in Webtoons extension

### DIFF
--- a/src/en/webtoons/src/eu/kanade/tachiyomi/extension/en/webtoons/Webtoons.kt
+++ b/src/en/webtoons/src/eu/kanade/tachiyomi/extension/en/webtoons/Webtoons.kt
@@ -125,7 +125,7 @@ class Webtoons : ParsedHttpSource() {
         manga.genre = detailElement.select(".genre").map { it.text() }.joinToString(", ")
         manga.description = infoElement.select("p.summary").text()
         manga.status = infoElement.select("p.day_info").text().orEmpty().let { parseStatus(it) }
-        manga.thumbnail_url = discoverPic.select("img").not("[alt=Representative image").first()?.attr("src") ?: picElement.attr("style")?.substringAfter("url(")?.substringBeforeLast(")")
+        manga.thumbnail_url = discoverPic.select("img").not("[alt='Representative image']").first()?.attr("src") ?: picElement.attr("style")?.substringAfter("url(")?.substringBeforeLast(")")
         return manga
     }
 


### PR DESCRIPTION
Does not affect Tachiyomi currently as JSoup is lenient when parsing CSS selectors