### PR TITLE
manhuaren: make manga urls consistent

### DIFF
--- a/src/zh/manhuaren/build.gradle
+++ b/src/zh/manhuaren/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Manhuaren'
     pkgNameSuffix = 'zh.manhuaren'
     extClass = '.Manhuaren'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Include only the manga id in SManga.url. The remaining required parameters
are attached by overriding *Request() functions.

This makes manga urls consistent, so mangas already in the library will
be correctly displayed as such, and user won't be able to add the same
manga to the library multiple times (although mangas added to the
library before this update will still have this problem).