### PR TITLE
ComiCake: Fixed date format for older Android API

### DIFF
--- a/src/all/comicake/build.gradle
+++ b/src/all/comicake/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: ComiCake'
     pkgNameSuffix = "all.comicake"
     extClass = '.ComiCakeFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/all/comicake/src/eu/kanade/tachiyomi/extension/en/comicake/ComiCake.kt
+++ b/src/all/comicake/src/eu/kanade/tachiyomi/extension/en/comicake/ComiCake.kt
@@ -122,7 +122,7 @@ open class ComiCake(override val name: String, override val baseUrl: String, ove
     private fun parseChapterJson(obj: JSONObject) = SChapter.create().apply {
         name = obj.getString("title") // title will always have content, vs. name that's an optional field
         chapter_number = (obj.getInt("chapter") + (obj.getInt("subchapter") / 10.0)).toFloat()
-        date_upload = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse(obj.getString("published_at")).time
+        date_upload = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZZZ").parse(obj.getString("published_at")).time
         // TODO scanlator field by adding team to expandable in CC (low priority given the use case of CC)
         url = obj.getString("manifest")
     }


### PR DESCRIPTION
Addresses one of the issues with older Android versions. (#354)
Referenced in documentation here: https://developer.android.com/reference/java/text/SimpleDateFormat.html
The use of 'X' only works above API 24. 'Z' is universally used and fixes the issue.
I have tested this on Lollipop 5.0 and Nougat 7.0. 