### PR TITLE
Fix MangaDex R18+ filter

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 54
+    extVersionCode = 55
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
More specifically, fixes how cookies are added to requests.

It seems that the R18+ cookie still works, but the language filtering one (`mangadex_filter_langs`) is no longer a thing.