### PR TITLE
Open in browser workaround for MangAdventure

### DIFF
--- a/src/all/mangadventure/build.gradle
+++ b/src/all/mangadventure/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangAdventure'
     pkgNameSuffix = 'all.mangadventure'
     extClass = '.MangAdventureFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
This PR fixes the `Open in browser` action for the MangAdventure extension based on the workaround in  alessandrojean/tachiyomi-extensions@385abf9. Closes inorichi/tachiyomi#1755.