### PR TITLE
Adds a .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# Editor configuration, see https://editorconfig.org
+root = true
+
+[*.kt]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+


### PR DESCRIPTION
Adds the `.editorconfig` file to keep code style similar on supporting configurations.

Also prevents the case where spaces are switched to tabs when the editor disagrees.