### PR TITLE
[Mangadex] Change default sort selection to match popularMangaRequest behavior

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 62
+    extVersionCode = 63
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -97,6 +97,7 @@ open class Mangadex(override val lang: String, private val internalLang: String,
 
     override fun latestUpdatesSelector() = "tr a.manga_title"
 
+    // url matches default SortFilter selection (Rating Descending)
     override fun popularMangaRequest(page: Int): Request {
         return GET("$baseUrl/titles/7/$page/", headersBuilder().build())
     }
@@ -574,9 +575,10 @@ open class Mangadex(override val lang: String, private val internalLang: String,
     private class TagInclusionMode : Filter.Select<String>("Tag inclusion mode", arrayOf("All (and)", "Any (or)"), 0)
     private class TagExclusionMode : Filter.Select<String>("Tag exclusion mode", arrayOf("All (and)", "Any (or)"), 1)
 
+    // default selection (Rating Descending) matches popularMangaRequest url
     class SortFilter : Filter.Sort("Sort",
             sortables.map { it.first }.toTypedArray(),
-            Filter.Sort.Selection(0, true))
+            Filter.Sort.Selection(3, false))
 
     private class OriginalLanguage : Filter.Select<String>("Original Language", SOURCE_LANG_LIST.map { it -> it.first }.toTypedArray())
 


### PR DESCRIPTION
The app defaults to popularManga when no sorting options are selected, so the default sort should be updated to match that behavior instead of showing 'update date'. In this case, that default sort should be 'rating descending'.