### PR TITLE
Foolslide refresh

### DIFF
--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: FoolSlide'
     pkgNameSuffix = "all.foolslide"
     extClass = '.FoolSlideFactory'
-    extVersionCode = 19
+    extVersionCode = 20
     libVersion = '1.2'
 }
 

--- a/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlideFactory.kt
+++ b/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlideFactory.kt
@@ -19,20 +19,14 @@ fun getAllFoolSlide(): List<Source> {
         JaminisBox(),
         HelveticaScans(),
         SenseScans(),
-        SeaOtterScans(),
         KireiCake(),
-        HiranoMoeScansBureau(),
         SilentSky(),
         Mangatellers(),
         IskultripScans(),
-        PinkFatale(),
         AnataNoMotokare(),
         DeathTollScans(),
         DKThias(),
-        MangaichiScanlationDivision(),
         WorldThree(),
-        TheCatScans(),
-        AngelicScanlations(),
         DokiFansubs(),
         YuriIsm(),
         AjiaNoScantrad(),
@@ -48,9 +42,9 @@ fun getAllFoolSlide(): List<Source> {
         EvilFlowers(),
         AkaiYuhiMunTeam(),
         LupiTeam(),
-        HotChocolateScans(),
         HentaiCafe(),
-        ShoujoSense()
+        ShoujoSense(),
+        TheCatScans()
     )
 }
 
@@ -72,17 +66,13 @@ class JaminisBox : FoolSlide("Jaimini's Box", "https://jaiminisbox.com", "en", "
     }
 }
 
-class HotChocolateScans : FoolSlide("Hot Chocolate Scans", "http://hotchocolatescans.com", "en", "/fs")
+class TheCatScans : FoolSlide("The Cat Scans", "https://reader2.thecatscans.com/", "en")
 
 class HelveticaScans : FoolSlide("Helvetica Scans", "https://helveticascans.com", "en", "/r")
 
 class SenseScans : FoolSlide("Sense-Scans", "https://sensescans.com", "en", "/reader")
 
-class SeaOtterScans : FoolSlide("Sea Otter Scans", "https://reader.seaotterscans.com", "en")
-
 class KireiCake : FoolSlide("Kirei Cake", "https://reader.kireicake.com", "en")
-
-class HiranoMoeScansBureau : FoolSlide("HiranoMoe Scans Bureau", "https://hiranomoe.com", "en", "/r")
 
 class SilentSky : FoolSlide("Silent Sky", "http://reader.silentsky-scans.net", "en")
 
@@ -94,9 +84,7 @@ class Mangatellers : FoolSlide("Mangatellers", "http://www.mangatellers.gr", "en
 
 class IskultripScans : FoolSlide("Iskultrip Scans", "http://www.maryfaye.net", "en", "/reader")
 
-class PinkFatale : FoolSlide("PinkFatale", "http://manga.pinkfatale.net", "en")
-
-class AnataNoMotokare : FoolSlide("Anata no Motokare", "https://motokare.maos.ca", "en")
+class AnataNoMotokare : FoolSlide("Anata no Motokare", "https://motokare.xyz", "en", "/reader")
 
 class DeathTollScans : FoolSlide("Death Toll Scans", "https://reader.deathtollscans.net", "en")
 
@@ -106,39 +94,11 @@ class DKThias : FoolSlide("DKThias Scanlations", "http://reader.dkthias.com", "e
     }
 }
 
-class MangaichiScanlationDivision : FoolSlide("Mangaichi Scanlation Division", "http://mangaichiscans.mokkori.fr", "en", "/fs")
-
 class WorldThree : FoolSlide("World Three", "http://www.slide.world-three.org", "en")
-
-class TheCatScans : FoolSlide("The Cat Scans", "https://reader.thecatscans.com", "en")
-
-class AngelicScanlations : FoolSlide("Angelic Scanlations", "http://www.angelicscans.net", "en", "/foolslide") {
-    override fun latestUpdatesSelector() = "div.list > div.releases"
-
-    override fun popularMangaSelector() = ".grouped > .series-block"
-
-    override fun mangaDetailsParse(document: Document): SManga {
-        return SManga.create().apply {
-            thumbnail_url = document.select(".preview > img").attr("src")
-
-            val info = document.select(".data").first()
-            title = info.select("h2.title").text().trim()
-            val authorArtist = info.select(".author").text().split("/")
-            author = authorArtist.getOrNull(0)?.trim()
-            artist = authorArtist.getOrNull(1)?.trim()
-
-            description = info.ownText().trim()
-        }
-    }
-
-    override fun chapterListSelector() = ".list > .release"
-
-    override val chapterDateSelector = ".metadata"
-}
 
 class DokiFansubs : FoolSlide("Doki Fansubs", "https://kobato.hologfx.com", "en", "/reader")
 
-class YuriIsm : FoolSlide("Yuri-ism", "https://reader.yuri-ism.com", "en", "/slide")
+class YuriIsm : FoolSlide("Yuri-ism", "https://www.yuri-ism.net", "en", "/slide")
 
 class AjiaNoScantrad : FoolSlide("Ajia no Scantrad", "https://ajianoscantrad.fr", "fr", "/reader")
 

--- a/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlideFactory.kt
+++ b/src/all/foolslide/src/eu/kanade/tachiyomi/extension/en/foolslide/FoolSlideFactory.kt
@@ -32,13 +32,11 @@ fun getAllFoolSlide(): List<Source> {
         AjiaNoScantrad(),
         OneTimeScans(),
         TsubasaSociety(),
-        Helheim(),
         MangaScouts(),
         StormInHeaven(),
         Lilyreader(),
         MidnightHaven(),
         Russification(),
-        NieznaniReader(),
         EvilFlowers(),
         AkaiYuhiMunTeam(),
         LupiTeam(),
@@ -106,8 +104,6 @@ class OneTimeScans : FoolSlide("One Time Scans", "https://otscans.com", "en", "/
 
 class TsubasaSociety : FoolSlide("Tsubasa Society", "https://www.tsubasasociety.com", "en", "/reader/master/Xreader")
 
-class Helheim : FoolSlide("Helheim", "http://helheim.pl", "pl", "/reader")
-
 class MangaScouts : FoolSlide("MangaScouts", "http://onlinereader.mangascouts.org", "de")
 
 class StormInHeaven : FoolSlide("Storm in Heaven", "http://www.storm-in-heaven.net", "it", "/reader-sih")
@@ -117,8 +113,6 @@ class Lilyreader : FoolSlide("Lilyreader", "https://manga.smuglo.li", "en")
 class MidnightHaven : FoolSlide("Midnight Haven", "http://midnighthaven.shounen-ai.net", "en", "/reader")
 
 class Russification : FoolSlide("Русификация", "https://rusmanga.ru", "ru")
-
-class NieznaniReader : FoolSlide("Nieznani", "http://reader.nieznani.mynindo.pl", "pl")
 
 class EvilFlowers : FoolSlide("Evil Flowers", "http://reader.evilflowers.com", "en")
 


### PR DESCRIPTION
Can close: https://github.com/inorichi/tachiyomi-extensions/issues/702

Removed dead sources:
Sea Otter Scans - website points to MangaDex
Hirano MoeScans Bureau - dead, long term
PinkFatale - dead, long term
Mangaichi Scanlation Division - dead for months
Angelic Scanlations - dead, long term
Hot Chocolate Scans - dead for months
NieznaniReader - dead, long term
Helheim - dead, long term

Url change:
Anata No Motokare
The Cat Scans
Yuri-ism