### PR TITLE
Check if Mangahere manga is licensed

### DIFF
--- a/src/en/mangahere/build.gradle
+++ b/src/en/mangahere/build.gradle
@@ -5,12 +5,14 @@ ext {
     appName = 'Tachiyomi: Mangahere'
     pkgNameSuffix = 'en.mangahere'
     extClass = '.Mangahere'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 
 dependencies {
     compileOnly project(':duktape-stub')
+    sourceCompatibility = "1.6"
+    targetCompatibility = "1.6"
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -4,6 +4,7 @@ import com.squareup.duktape.Duktape
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.*
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -146,6 +147,11 @@ class Mangahere : ParsedHttpSource() {
                 else -> manga.status = SManga.UNKNOWN
             }
         }
+
+        // Get a chapter, check if the manga is licensed.
+        val aChapterURL = chapterFromElement(document.select(chapterListSelector()).first()).url
+        val aChapterDocument = client.newCall(GET("$baseUrl$aChapterURL", headers)).execute().asJsoup()
+        if (aChapterDocument.select("p.detail-block-content").hasText()) manga.status = SManga.LICENSED
 
         return manga
     }


### PR DESCRIPTION
Mangahere doesn't mark their manga as licensed on their manga's details page, only on the chapters themselves.  With this, Tachiyomi will request a chapter and parse the response to see if the manga is licensed and mark it so if it is.

Added those 2 lines to the gradle to stop Android Studio giving a compiler warning.