### PR TITLE
Mangareader fixes and improvements

### DIFF
--- a/src/en/mangareader/build.gradle
+++ b/src/en/mangareader/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangareader'
     pkgNameSuffix = 'en.mangareader'
     extClass = '.Mangareader'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Latest updates request wasn't working anymore, fixed that.

Changed sort order for chapters--source provided them oldest to newest, now it's newest to oldest in Tachiyomi (how most sources are).

Chapters should show titles now if they have them (Chapter #: Title vs just Chapter #)

Better handling of getting the next pages of popular/latest/search.