### PR TITLE
Madara tweaks

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -6,13 +6,10 @@ import eu.kanade.tachiyomi.source.SourceFactory
 import java.text.SimpleDateFormat
 import java.util.*
 import eu.kanade.tachiyomi.network.GET
-import eu.kanade.tachiyomi.network.POST
-import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.source.model.SManga
-import okhttp3.CacheControl
-import okhttp3.FormBody
+import eu.kanade.tachiyomi.source.model.*
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.Request
-import org.jsoup.nodes.Element
+import okhttp3.Response
 
 class MadaraFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
@@ -53,7 +50,38 @@ class ZeroScans : Madara("ZeroScans", "https://zeroscans.com", "en")
 class IsekaiScanCom : Madara("IsekaiScan.com", "http://isekaiscan.com/", "en")
 class HappyTeaScans : Madara("Happy Tea Scans", "https://happyteascans.com/", "en")
 class JustForFun : Madara("Just For Fun", "https://just-for-fun.ru/", "ru", dateFormat = SimpleDateFormat("dd/MM/yy", Locale.US))
-class AoCTranslations : Madara("Agent of Change Translations", "https://aoc.moe/", "en")
+class AoCTranslations : Madara("Agent of Change Translations", "https://aoc.moe/", "en") {
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = mutableListOf<SChapter>()
+        val document = response.asJsoup()
+
+        // For when it's a normal chapter list
+        if (document.select(chapterListSelector()).hasText()) {
+            document.select(chapterListSelector())
+                .filter { it.select("a").attr("href").contains(baseUrl)}
+                .map { chapters.add(chapterFromElement(it)) }
+        } else {
+        // For their "fancy" volume/chapter lists
+            document.select("div.wpb_wrapper:contains(volume) a")
+                .filter { it.attr("href").contains(baseUrl) && !it.attr("href").contains("imgur")}
+                .map {
+                    val chapter = SChapter.create()
+                    if (it.attr("href").contains("volume")) {
+                        val volume = it.attr("href").substringAfter("volume-").substringBefore("/")
+                        val volChap = it.attr("href").substringAfter("volume-$volume/").substringBefore("/").replace("-", " ").capitalize()
+                        chapter.name = "Volume $volume - $volChap"
+                    } else {
+                        chapter.name = it.attr("href").substringBefore("/p").substringAfterLast("/").replace("-", " ").capitalize()
+                    }
+                    it.attr("href").let {
+                        chapter.setUrlWithoutDomain(it.substringBefore("?") + if (!it.endsWith("?style=list")) "?style=list" else "")
+                        chapters.add(chapter)
+                    }
+                }
+        }
+        return chapters.reversed()
+    }
+}
 class Kanjiku : Madara("Kanjiku", "https://kanjiku.net/", "de", dateFormat = SimpleDateFormat("dd. MMM yyyy", Locale.GERMAN))
 class KomikGo : Madara("KomikGo", "https://komikgo.com/", "id")
 class LuxyScans : Madara("Luxy Scans", "https://luxyscans.com/", "en")
@@ -63,16 +91,34 @@ class TritiniaScans : Madara("Tritinia Scans", "http://tritiniascans.ml/", "en")
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request = GET("$baseUrl/index.html?s=$query", headers)
     override fun latestUpdatesNextPageSelector(): String? = null
     override fun popularMangaNextPageSelector(): String? = null
-
 }
 class TsubakiNoScan : Madara("Tsubaki No Scan", "https://tsubakinoscan.com/", "fr", dateFormat = SimpleDateFormat("dd/MM/yy", Locale.US))
 class YokaiJump : Madara("Yokai Jump", "https://yokaijump.fr/", "fr", dateFormat = SimpleDateFormat("dd/MM/yy", Locale.US))
 class ZManga : Madara("ZManga", "https://zmanga.org/", "es")
-class MangazukiMe : Madara("Mangazuki.me", "https://mangazuki.me/", "en")
-class MangazukiOnline : Madara("Mangazuki.online", "https://www.mangazuki.online/", "en")
+class MangazukiMe : Madara("Mangazuki.me", "https://mangazuki.me/", "en"){
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = mutableListOf<SChapter>()
+        response.asJsoup().select(chapterListSelector())
+            .filter { it.select("a").attr("href").contains(baseUrl) }
+            .map { chapters.add(chapterFromElement(it)) }
+        return chapters
+    }
+}
+class MangazukiOnline : Madara("Mangazuki.online", "https://www.mangazuki.online/", "en") {
+    override fun chapterListSelector() = "li.wp-manga-chapter:has(a)"
+    override fun chapterListParse(response: Response): List<SChapter> {
+        val chapters = mutableListOf<SChapter>()
+        response.asJsoup().select(chapterListSelector())
+            .filter { it.select("a").attr("href").contains(baseUrl) }
+            .map { chapters.add(chapterFromElement(it)) }
+        return chapters
+    }
+}
 class MangazukiClubJP : Madara("Mangazuki.club", "https://mangazuki.club/", "ja")
 class MangazukiClubKO : Madara("Mangazuki.club", "https://mangazuki.club/", "ko")
-class FirstKissManga : Madara("1st Kiss", "https://1stkissmanga.com/", "en")
+class FirstKissManga : Madara("1st Kiss", "https://1stkissmanga.com/", "en") {
+    override val pageListParseSelector = "div.reading-content img"
+}
 class Mangalike : Madara("Mangalike", "https://mangalike.net/", "en")
 class MangaSY : Madara("Manga SY", "https://www.mangasy.com/", "en")
 class ManwhaClub : Madara("Manwha Club", "https://manhwa.club/", "en")


### PR DESCRIPTION
Fixed a few sources that had broken chapters, think they were 1stKiss, Yokai, Tritinia, maybe others.

Filtering out chapters in Mangazuki.me and Mangazuki.online that aren't hosted on their own sites.  I think it's better to potentially have a "no chapters found" message pop up rather than clicking on chapters that get you nothing.

Fixed Mangazuki.online lateinit error.

New chapter dates are sometimes represented by a graphic instead of a text date, now parsing that image's alt text for a date.

Cleaned up some no longer used imports.

AOC is a little nutty.  Like Mangazuki they link chapters to sites other than their own (MangaDex and Imgur)--filtered those out.  Also, they have 2 different ways of managing their chapters--one's a simple chapter list and the other is by volume and chapter.  The second form was causing an empty chapter list in Tachiyomi; we're parsing both forms now.  Finally, reversed their chapter order to be in-line with usual source order.