### PR TITLE
Fixed relative date parsing for 'n minutes ago' in Genkan

### DIFF
--- a/src/all/genkan/build.gradle
+++ b/src/all/genkan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Genkan (multiple sources)'
     pkgNameSuffix = 'all.genkan'
     extClass = '.GenkanFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/all/genkan/src/eu/kanade/tachiyomi/extension/all/genkan/Genkan.kt
+++ b/src/all/genkan/src/eu/kanade/tachiyomi/extension/all/genkan/Genkan.kt
@@ -182,7 +182,7 @@ abstract class Genkan(
                 "week" -> calendar.apply{add(Calendar.WEEK_OF_MONTH, -trimmedDate[0].toInt())}
                 "day" -> calendar.apply{add(Calendar.DAY_OF_MONTH, -trimmedDate[0].toInt())}
                 "hour" -> calendar.apply{add(Calendar.HOUR_OF_DAY, -trimmedDate[0].toInt())}
-                "minute" -> calendar.apply{add(Calendar.MONTH, -trimmedDate[0].toInt())}
+                "minute" -> calendar.apply{add(Calendar.MINUTE, -trimmedDate[0].toInt())}
                 "second" -> calendar.apply{add(Calendar.SECOND, 0)}
             }
 


### PR DESCRIPTION
Fixes an issue where relative dates in the format of 'n minutes ago' where wrongly parsed as 'n months ago', resulting in chapters not displaying in the "Library updates" tab.