### PR TITLE
Webcomics: Limit to 20 chapters

### DIFF
--- a/src/en/webcomics/build.gradle
+++ b/src/en/webcomics/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Webcomics'
     pkgNameSuffix = 'en.webcomics'
     extClass = '.Webcomics'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/webcomics/src/eu/kanade/tachiyomi/extension/en/webcomics/Webcomics.kt
+++ b/src/en/webcomics/src/eu/kanade/tachiyomi/extension/en/webcomics/Webcomics.kt
@@ -123,9 +123,12 @@ class Webcomics : ParsedHttpSource() {
         } else {
             val chapters = mutableListOf<SChapter>()
             for (i in 1..20)
-            document.select("${chapterListSelector()}:nth-child($i)").map{
-                chapters.add(chapterFromElement(it))
-            }
+                document.select("${chapterListSelector()}:nth-child($i)").map { chapters.add(chapterFromElement(it)) }
+            // Add a chapter notifying the user of the situation
+            val lockedNotification = SChapter.create()
+            lockedNotification.name = "[Attention] Additional chapters are restricted by the source to their own app"
+            lockedNotification.url = "wiki.html"
+            chapters.add(lockedNotification)
             return chapters.reversed()
         }
     }

--- a/src/en/webcomics/src/eu/kanade/tachiyomi/extension/en/webcomics/Webcomics.kt
+++ b/src/en/webcomics/src/eu/kanade/tachiyomi/extension/en/webcomics/Webcomics.kt
@@ -56,6 +56,9 @@ class Webcomics : ParsedHttpSource() {
         manga.genre = infoElement.select(".labels > label").joinToString(", ") { it.text() }
         manga.description = infoElement.select("p.p-description").text()
         manga.thumbnail_url = infoElement.select("img").first()?.attr("src")
+        infoElement.select("p.p-schedule:first-of-type").text().let {
+            if (it.contains("IDK")) manga.status = SManga.COMPLETED else manga.status = SManga.ONGOING
+        }
         return manga
     }
 
@@ -112,7 +115,19 @@ class Webcomics : ParsedHttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
-        return document.select(chapterListSelector()).asReversed().map {chapterFromElement(it)}
+
+        /* Source only allows 20 chapters to be readable on their website, trying to read past
+           that results in a page list empty error; so might as well not grab them. */
+        if (document.select("${chapterListSelector()}:nth-child(21)").isEmpty()) {
+            return document.select(chapterListSelector()).asReversed().map { chapterFromElement(it) }
+        } else {
+            val chapters = mutableListOf<SChapter>()
+            for (i in 1..20)
+            document.select("${chapterListSelector()}:nth-child($i)").map{
+                chapters.add(chapterFromElement(it))
+            }
+            return chapters.reversed()
+        }
     }
 
     override fun chapterFromElement(element: Element): SChapter {


### PR DESCRIPTION
Source only allows 20 chapters per manga, after that they're locked to their own app.  Since they're unavailable to us, might as well not create chapters past 20.  Also added manga.status to details.

Closes https://github.com/inorichi/tachiyomi-extensions/issues/1298