### PR TITLE
Mangadex: Throw custom message if chapters is empty

### DIFF
--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -421,7 +421,12 @@ open class Mangadex(override val lang: String, private val internalLang: String,
                 chapters.add(chapterFromJson(key, chapterElement, finalChapterNumber, status))
             }
         }
-        return chapters
+
+        if (chapters.isEmpty()) {
+            throw Exception("Chapters is empty or there are no chapters in your selected language")
+        } else {
+            return chapters
+        }
     }
 
     private fun chapterFromJson(chapterId: String, chapterJson: JsonObject, finalChapterNumber: String, status: Int): SChapter {


### PR DESCRIPTION
Empty chapters usually divided into two reason:
1. Can't parse chapters
2. Its not have chapters

On mangadex case, empty chapters can happen due to skipped chapters when not matching selected language