### PR TITLE
Additional bug-fixes and improvements to Guya extension.

### DIFF
--- a/src/en/guya/build.gradle
+++ b/src/en/guya/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Guya'
     pkgNameSuffix = "en.guya"
     extClass = '.Guya'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
An API change broke the page list request, so this update fixes that. 

I also took the opportunity to clean up the code a bit, sneak some additional user-agent info in the header, and add a description for the preferred scanlator option. 