### PR TITLE
MyReadingManga Chapter Names Parsing

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -146,7 +146,7 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
             it.forEach {
                 if (!it.text().contains("Next »", true)) {
                     val pageNumber = it.text()
-                    val chname = document.select(".chapter-class a[href$=/$pageNumber/]").text().ifEmpty { "Ch. $pageNumber" }.capitalize()
+                    val chname = document.select(".chapter-class a[href$=/$pageNumber/]")?.text()?.ifEmpty { "Ch. $pageNumber" }?.capitalize() ?:"Ch. $pageNumber"
                     chapters.add(createChapter(it.text(), document.baseUri(), date, chname))
                 }
             }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -132,18 +132,22 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
 
     override fun chapterListSelector() = ".entry-pagination a"
 
+
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val chapters = mutableListOf<SChapter>()
 
         val date = parseDate(document.select(".entry-time").attr("datetime").substringBefore("T"))
+        val ch1name = document.select(".chapter-class a")?.first()?.text()?.capitalize() ?:"Chapter 1"
         //create first chapter since its on main manga page
-        chapters.add(createChapter("1", document.baseUri(), date))
+        chapters.add(createChapter("1", document.baseUri(), date, ch1name))
         //see if there are multiple chapters or not
         document.select(chapterListSelector())?.let { it ->
             it.forEach {
                 if (!it.text().contains("Next »", true)) {
-                    chapters.add(createChapter(it.text(), document.baseUri(), date))
+                    val pageNumber = it.text()
+                    val chname = document.select(".chapter-class a[href$=/$pageNumber/]")?.text()?.capitalize()
+                    chapters.add(createChapter(it.text(), document.baseUri(), date, chname))
                 }
             }
         }
@@ -156,10 +160,10 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         return SimpleDateFormat("yyyy-MM-dd").parse(date).time
     }
 
-    private fun createChapter(pageNumber: String, mangaUrl: String, date: Long): SChapter {
+    private fun createChapter(pageNumber: String, mangaUrl: String, date: Long, chname: String?): SChapter {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain("$mangaUrl/$pageNumber")
-        chapter.name = "Ch. $pageNumber"
+        chapter.name = chname ?:"Chapter $pageNumber"
         chapter.date_upload = date
         return chapter
     }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -132,21 +132,20 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
 
     override fun chapterListSelector() = ".entry-pagination a"
 
-
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val chapters = mutableListOf<SChapter>()
 
         val date = parseDate(document.select(".entry-time").attr("datetime").substringBefore("T"))
-        val ch1name = document.select(".chapter-class a")?.first()?.text()?.capitalize() ?:"Chapter 1"
+        val chfirstname = document.select(".chapter-class a")?.first()?.text()?.capitalize() ?:"Ch. 1"
         //create first chapter since its on main manga page
-        chapters.add(createChapter("1", document.baseUri(), date, ch1name))
+        chapters.add(createChapter("1", document.baseUri(), date, chfirstname))
         //see if there are multiple chapters or not
         document.select(chapterListSelector())?.let { it ->
             it.forEach {
                 if (!it.text().contains("Next »", true)) {
                     val pageNumber = it.text()
-                    val chname = document.select(".chapter-class a[href$=/$pageNumber/]")?.text()?.capitalize()
+                    val chname = document.select(".chapter-class a[href$=/$pageNumber/]").text().ifEmpty { "Ch. $pageNumber" }.capitalize()
                     chapters.add(createChapter(it.text(), document.baseUri(), date, chname))
                 }
             }
@@ -160,10 +159,10 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         return SimpleDateFormat("yyyy-MM-dd").parse(date).time
     }
 
-    private fun createChapter(pageNumber: String, mangaUrl: String, date: Long, chname: String?): SChapter {
+    private fun createChapter(pageNumber: String, mangaUrl: String, date: Long, chname: String): SChapter {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain("$mangaUrl/$pageNumber")
-        chapter.name = chname ?:"Chapter $pageNumber"
+        chapter.name = chname
         chapter.date_upload = date
         return chapter
     }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -137,7 +137,8 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         val chapters = mutableListOf<SChapter>()
 
         val date = parseDate(document.select(".entry-time").attr("datetime").substringBefore("T"))
-        val chfirstname = document.select(".chapter-class a")?.first()?.text()?.capitalize() ?:"Ch. 1"
+        val mangaUrl = document.baseUri()
+        val chfirstname = document.select(".chapter-class a[href*=$mangaUrl]")?.first()?.text()?.ifEmpty { "Ch. 1" }?.capitalize() ?:"Ch. 1"
         //create first chapter since its on main manga page
         chapters.add(createChapter("1", document.baseUri(), date, chfirstname))
         //see if there are multiple chapters or not


### PR DESCRIPTION
Additional Features:

- Parses chapter names from manga page when available
If chapter names do not exist, uses previous numbers system based off of page number. 

Resulting Fixes:

- "Extras" no longer show as a chapter new chapter number (eg Extra or Chapter 21.5)
- Chapters after extras appear with correct chapter numbers
- Some manga volumes are split into another entry and do not start on chapter 1, example:
Blue Sky Complex v01 (Ch 1-6) and Blue Sky Complex (7-19)



