### PR TITLE
Genkan search update

### DIFF
--- a/src/all/genkan/build.gradle
+++ b/src/all/genkan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Genkan (multiple sources)'
     pkgNameSuffix = 'all.genkan'
     extClass = '.GenkanFactory'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 

--- a/src/all/genkan/src/eu/kanade/tachiyomi/extension/all/genkan/GenkanFactory.kt
+++ b/src/all/genkan/src/eu/kanade/tachiyomi/extension/all/genkan/GenkanFactory.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.source.SourceFactory
 class GenkanFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
             LeviatanScans(),
+            LeviatanScansES(),
             PsychoPlay(),
             OneShotScans(),
             KaguyaDex(),
@@ -13,9 +14,13 @@ class GenkanFactory : SourceFactory {
             HunlightScans())
 }
 
+/* Genkan class is for the latest version of Genkan CMS
+   GenkanOriginal is for the initial version of the CMS that didn't have its own search function  */
+
 class LeviatanScans : Genkan("Leviatan Scans", "https://leviatanscans.com", "en")
+class LeviatanScansES : GenkanOriginal("Leviatan Scans", "https://es.leviatanscans.com", "es")
 class PsychoPlay : Genkan("Psycho Play", "https://psychoplay.co", "en")
 class OneShotScans : Genkan("One Shot Scans", "https://oneshotscans.com", "en")
-class KaguyaDex : Genkan("KaguyaDex", " https://kaguyadex.com", "en")
-class KomiScans : Genkan("Komi Scans", " https://komiscans.com", "en")
+class KaguyaDex : GenkanOriginal("KaguyaDex", " https://kaguyadex.com", "en")
+class KomiScans : GenkanOriginal("Komi Scans", " https://komiscans.com", "en")
 class HunlightScans : Genkan("Hunlight Scans", "https://hunlight-scans.info", "en")


### PR DESCRIPTION
The Genkan CMS updated and now has its own search function, but not all the sites using Genkan have updated.  I've shifted the sources to using their site's search where possible; still doing client-side search for 2 of the original sources.

Leviatan Scans has Spanish translated manga available again, so I've added that.  Although they're one of the sites that's updated, search is broken for the Spanish version; so for now the Spanish version gets searched client-side unlike the English version.

Reworded a couple comments.