### PR TITLE
Added support for new recommended sort API response.

### DIFF
--- a/src/en/guya/build.gradle
+++ b/src/en/guya/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Guya'
     pkgNameSuffix = "en.guya"
     extClass = '.Guya'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
The site now offers a new response field in its API, which allows us to choose the best scanlators for a particular chapter, if a preferred one isn't set or hasn't contributed for that particular chapter. This change just supports that option. 