### PR TITLE
MangaCards: URL assignment fix

### DIFF
--- a/src/all/mangacards/build.gradle
+++ b/src/all/mangacards/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaCards (Valhalla, NANI?)'
     pkgNameSuffix = 'all.mangacards'
     extClass = '.MangaCardsFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/all/mangacards/src/eu/kanade/tachiyomi/extension/all/mangacards/MangaCards.kt
+++ b/src/all/mangacards/src/eu/kanade/tachiyomi/extension/all/mangacards/MangaCards.kt
@@ -153,7 +153,7 @@ abstract class MangaCards (
         val body = FormBody.Builder()
             .add("mode", "Webtoon")
             .build()
-        return POST("$baseUrl/${chapter.url}", headers, body)
+        return POST("$baseUrl${chapter.url}", headers, body)
     }
 
     override fun pageListParse(document: Document): List<Page> {


### PR DESCRIPTION
Current extension is 404ing on both sites due to how the URL was managed before. This change fixes both of them.