### PR TITLE
Make uses-feature:tachiyomi.extension optional, and Allow backups.

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -4,7 +4,7 @@
 
     <uses-feature android:name="tachiyomi.extension" android:required="false"/>
 
-    <application android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:label="${appName}">
+    <application android:icon="@mipmap/ic_launcher" android:label="${appName}">
 
         <meta-data android:name="tachiyomi.extension.class" android:value="${extClass}" />
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="eu.kanade.tachiyomi.extension">
 
-    <uses-feature android:name="tachiyomi.extension" />
+    <uses-feature android:name="tachiyomi.extension" android:required="false"/>
 
     <application android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:label="${appName}">
 


### PR DESCRIPTION
1. I am trying to republish the Tachiyomi Extensions in an fdroid repository, and uses-feature:tachiyomi.extension is breaking it. In order to install tachiyomi extensions at all via fdroid, I have to enable "include incompatible versions", and updating the ~~app~~ extension is entirely impossible.

2. allowBackup is almost certainly not intended to be enabled. This isn't a banking app, and the extensions don't store private data. I noticed this during above.