### PR TITLE
[Komga] request converted image from server if format is not supported

### DIFF
--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.Komga'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/Komga.kt
@@ -73,7 +73,12 @@ open class Komga : ConfigurableSource, HttpSource() {
     override fun pageListParse(response: Response): List<Page> {
         val pages = gson.fromJson<List<PageDto>>(response.body()?.charStream()!!)
         return pages.map {
-            val url = "${response.request().url()}/${it.number}"
+            val url = "${response.request().url()}/${it.number}" +
+                if (!supportedImageTypes.contains(it.mediaType)) {
+                    "?convert=png"
+                } else {
+                    ""
+                }
             Page(
                 index = it.number - 1,
                 imageUrl = url
@@ -177,5 +182,7 @@ open class Komga : ConfigurableSource, HttpSource() {
         private const val USERNAME_DEFAULT = ""
         private const val PASSWORD_TITLE = "Password"
         private const val PASSWORD_DEFAULT = ""
+
+        private val supportedImageTypes = listOf("image/jpeg", "image/png", "image/gif", "image/webp")
     }
 }

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
@@ -20,5 +20,6 @@ data class BookMetadataDto(
 
 data class PageDto(
     val number: Int,
-    val fileName: String
+    val fileName: String,
+    val mediaType: String
 )


### PR DESCRIPTION
Komga has the ability to convert images on the fly, since Tachiyomi cannot read some formats like `tiff`, it will request Komga server to convert if the raw format is not supported.