### PR TITLE
MangaRock chapter delay fix 2

### DIFF
--- a/src/en/mangarock/build.gradle
+++ b/src/en/mangarock/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Manga Rock'
     pkgNameSuffix = 'en.mangarock'
     extClass = '.MangaRock'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 

--- a/src/en/mangarock/src/eu/kanade/tachiyomi/extension/en/mangarock/MangaRock.kt
+++ b/src/en/mangarock/src/eu/kanade/tachiyomi/extension/en/mangarock/MangaRock.kt
@@ -12,7 +12,12 @@ import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.HttpSource
-import okhttp3.*
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody
 import org.json.JSONObject
 import rx.Observable
 import java.util.ArrayList
@@ -34,9 +39,6 @@ class MangaRock : HttpSource() {
     override val lang = "en"
 
     override val supportsLatest = true
-
-    override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("Origin", "https://mangarock.com")
 
     // Handles the page decoding
     override val client: OkHttpClient = super.client.newBuilder().addInterceptor(fun(chain): Response {
@@ -186,11 +188,11 @@ class MangaRock : HttpSource() {
     private fun getMangaApiRequest(manga: SManga): Request {
         // Handle older entries with API URL ("/info?oid=mrs-series-...")
         if (manga.url.startsWith("/info")) {
-            return GET("$apiUrl${manga.url}&country=", headers)
+            return GET("$apiUrl${manga.url}&Country=", headers)
         }
 
         val oid = manga.url.substringAfterLast("/")
-        return GET("$apiUrl/info?oid=$oid&country=", headers)
+        return GET("$apiUrl/info?oid=$oid&Country=", headers)
     }
 
     override fun mangaDetailsParse(response: Response) = SManga.create().apply {


### PR DESCRIPTION
It's interesting, the previous push _does_ fix the delay issue for some manga, but not all.  I've reverted that change and I'm pushing a different one.  I've checked the latest 20-25 manga at different points the last few days with this change and they've all been good; so I think this might be the one.  The solution was easy to overlook, needed to capitalize a parameter for chapter requests.