### PR TITLE
ReadMangaToday referer header

### DIFF
--- a/src/en/readmangatoday/build.gradle
+++ b/src/en/readmangatoday/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: ReadMangaToday'
     pkgNameSuffix = 'en.readmangatoday'
     extClass = '.Readmangatoday'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/en/readmangatoday/src/eu/kanade/tachiyomi/extension/en/readmangatoday/Readmangatoday.kt
+++ b/src/en/readmangatoday/src/eu/kanade/tachiyomi/extension/en/readmangatoday/Readmangatoday.kt
@@ -26,11 +26,13 @@ class Readmangatoday : ParsedHttpSource() {
     override val client: OkHttpClient get() = network.cloudflareClient
 
     /**
-     * Search only returns data with this set
+     * Search only returns data with user-agent and x-requeted-with set
+     * Referer needed due to some chapters linking images from other domains
      */
     override fun headersBuilder() = Headers.Builder().apply {
         add("User-Agent", "Mozilla/5.0 (Windows NT 6.3; WOW64)")
         add("X-Requested-With", "XMLHttpRequest")
+        add("Referer", baseUrl)
     }
 
     override fun popularMangaRequest(page: Int): Request {


### PR DESCRIPTION
Some of their chapters are linking to images outside their domain which can trigger a captcha without the right header.