### PR TITLE
all/webtoons: Add additonal languages

### DIFF
--- a/src/all/webtoons/build.gradle
+++ b/src/all/webtoons/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Webtoons'
     pkgNameSuffix = 'all.webtoons'
     extClass = '.WebtoonsFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsDefault.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsDefault.kt
@@ -9,7 +9,7 @@ import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.*
 
-open class WebtoonsDefault(override val lang: String) : Webtoons(lang) {
+open class WebtoonsDefault(override val lang: String, override val langCode: String = lang) : Webtoons(lang, langCode) {
 
     override fun chapterListSelector() = "ul#_episodeList > li[id*=episode]"
 
@@ -26,8 +26,12 @@ open class WebtoonsDefault(override val lang: String) : Webtoons(lang) {
         if (element.select(".ico_bgm").isNotEmpty()) {
             chapter.name += " ♫"
         }
-        chapter.date_upload = element.select("a > div.row > div.info > p.date").text()?.let { SimpleDateFormat("MMM d, yyyy", Locale.ENGLISH).parse(it).time } ?: 0
+        chapter.date_upload = element.select("a > div.row > div.info > p.date").text()?.let { chapterParseDate(it) } ?: 0
         return chapter
+    }
+
+    open fun chapterParseDate(date: String): Long {
+        return SimpleDateFormat("MMM d, yyyy", Locale.ENGLISH).parse(date).time
     }
 
     override fun chapterListRequest(manga: SManga) = GET("http://m.webtoons.com" + manga.url, mobileHeaders)

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
@@ -2,6 +2,9 @@ package eu.kanade.tachiyomi.extension.all.webtoons
 
 import eu.kanade.tachiyomi.extension.en.webtoons.WebtoonsEnglish
 import eu.kanade.tachiyomi.extension.fr.webtoons.WebtoonsFrench
+import eu.kanade.tachiyomi.extension.id.webtoons.WebtoonsIndonesian
+import eu.kanade.tachiyomi.extension.th.webtoons.WebtoonsThai
+import eu.kanade.tachiyomi.extension.zh.webtoons.WebtoonsChineseTraditional
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 
@@ -12,6 +15,9 @@ class WebtoonsFactory : SourceFactory {
 fun getAllWebtoons(): List<Source> {
     return listOf(
             WebtoonsEnglish(),
-            WebtoonsFrench()
+            WebtoonsChineseTraditional(),
+            WebtoonsFrench(),
+            WebtoonsIndonesian(),
+            WebtoonsThai()
     )
 }

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsTranslate.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsTranslate.kt
@@ -10,7 +10,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.util.*
 
-open class WebtoonsTranslate(override val lang: String, private val langCode: String) : Webtoons(lang) {
+open class WebtoonsTranslate(override val lang: String, private val translationLangCode: String) : Webtoons(lang) {
 
     private val apiBaseUrl = "https://global.apis.naver.com"
 
@@ -29,7 +29,7 @@ open class WebtoonsTranslate(override val lang: String, private val langCode: St
         val titleRegex = Regex("title_?[nN]o=([0-9]*)")
         val titleNo = titleRegex.find(original)!!.groupValues[1].toInt()
 
-        val chapterUrl = String.format("$apiBaseUrl$chapterListUrlPattern", titleNo, langCode)
+        val chapterUrl = String.format("$apiBaseUrl$chapterListUrlPattern", titleNo, translationLangCode)
         return GET(chapterUrl, headers)
     }
 

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/id/webtoons/WebtoonsIndonesian.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/id/webtoons/WebtoonsIndonesian.kt
@@ -1,0 +1,20 @@
+package eu.kanade.tachiyomi.extension.id.webtoons
+
+import eu.kanade.tachiyomi.extension.all.webtoons.WebtoonsDefault
+import java.util.*
+
+class WebtoonsIndonesian: WebtoonsDefault("en", "id") {
+    override val name: String = "Webtoons.com (Indonesian)"
+
+    // Android seems to be unable to parse Indonesian dates; we'll use a short hard-coded table
+    // instead.
+    private val DATE_MAP: Array<String> = arrayOf(
+        "Jan", "Feb", "Mar", "Apr", "Mei", "Jun", "Jul", "Agu", "Sep", "Okt", "Nov", "Des")
+
+    override fun chapterParseDate(date: String): Long {
+        val expr = Regex("""(\d{4}) ([A-Z][a-z]{2}) (\d{1,})""").find(date) ?: return 0
+        val (_, year, monthString, day) = expr.groupValues
+        val monthIndex = DATE_MAP.indexOf(monthString)
+        return GregorianCalendar(year.toInt(), monthIndex, day.toInt()).time.time
+    }
+}

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/th/webtoons/WebtoonsThai.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/th/webtoons/WebtoonsThai.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.extension.th.webtoons
+
+import eu.kanade.tachiyomi.extension.all.webtoons.WebtoonsDefault
+import java.text.SimpleDateFormat
+import java.util.*
+
+class WebtoonsThai: WebtoonsDefault("th") {
+    override fun chapterParseDate(date: String): Long {
+        return SimpleDateFormat("d MMM yyyy", Locale("th")).parse(date).time
+    }
+}

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/zh/webtoons/WebtoonsChineseTraditional.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/zh/webtoons/WebtoonsChineseTraditional.kt
@@ -1,0 +1,11 @@
+package eu.kanade.tachiyomi.extension.zh.webtoons
+
+import eu.kanade.tachiyomi.extension.all.webtoons.WebtoonsDefault
+import java.text.SimpleDateFormat
+import java.util.*
+
+class WebtoonsChineseTraditional: WebtoonsDefault("zh", "zh-hant") {
+    override fun chapterParseDate(date: String): Long {
+        return SimpleDateFormat("yyyy/MM/dd", Locale.TRADITIONAL_CHINESE).parse(date).time
+    }
+}


### PR DESCRIPTION
This adds more languages where webtoons has official comics:

- Chinese (Traditional)
- Indonesian
- Thai

Closes #1492

Note that Webtoons also has Chinese (Simplified) pages, but those go off into a separate host name, so I'm not touching that for now.

Also, as far as I can tell the French (unofficial translations) support is currently busted anyway; this PR does not fix it (since there's already quite a bit of changes here).  I might do a follow-up PR if that seems useful... though I note that there hasn't been an issue filed for it.

I'm not familiar with Kotlin (or Android development in general); please let me know if there is anything I can improve, I'd be happy to change things.

Thanks for the app and the various extensions!