### PR TITLE
Fix MangaLivre Cloudflare error

### DIFF
--- a/src/pt/mangasproject/build.gradle
+++ b/src/pt/mangasproject/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: mangásPROJECT'
     pkgNameSuffix = 'pt.mangasproject'
     extClass = '.MangasProjectFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 

--- a/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProject.kt
+++ b/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProject.kt
@@ -20,13 +20,16 @@ import java.util.*
 import java.util.concurrent.TimeUnit
 
 abstract class MangasProject(override val name: String,
-                    override val baseUrl: String) : HttpSource() {
+                             override val baseUrl: String) : HttpSource() {
+
     override val lang = "pt"
 
     override val supportsLatest = true
 
+    private val correctClient = if (name == "MangaLivre") network.cloudflareClient else network.client
+
     // Sometimes the site is slow.
-    override val client = network.client.newBuilder()
+    override val client = correctClient.newBuilder()
         .connectTimeout(1, TimeUnit.MINUTES)
         .readTimeout(1, TimeUnit.MINUTES)
         .writeTimeout(1, TimeUnit.MINUTES)
@@ -276,7 +279,7 @@ abstract class MangasProject(override val name: String,
         val token = TOKEN_REGEX.find(readerSrc)?.groupValues?.get(1) ?: ""
 
         if (token.isEmpty())
-            throw Exception("Mangá licenciado e removido pela editora.")
+            throw Exception("Não foi possível obter o token de leitura.")
 
         return chain.proceed(pageListApiRequest(request.url().toString(), token))
     }


### PR DESCRIPTION
Recently they started to use Cloudflare on one of the sites, so the extension are getting HTTP 503 errors. This PR should fix this.