### PR TITLE
Foolslide - OneTimeScans update

### DIFF
--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: FoolSlide'
     pkgNameSuffix = 'all.foolslide'
     extClass = '.FoolSlideFactory'
-    extVersionCode = 26
+    extVersionCode = 27
     libVersion = '1.2'
 }
 

--- a/src/all/foolslide/src/eu/kanade/tachiyomi/extension/all/foolslide/FoolSlideFactory.kt
+++ b/src/all/foolslide/src/eu/kanade/tachiyomi/extension/all/foolslide/FoolSlideFactory.kt
@@ -103,7 +103,7 @@ class YuriIsm : FoolSlide("Yuri-ism", "https://www.yuri-ism.net", "en", "/slide"
 
 class AjiaNoScantrad : FoolSlide("Ajia no Scantrad", "https://ajianoscantrad.fr", "fr", "/reader")
 
-class OneTimeScans : FoolSlide("One Time Scans", "https://otscans.com", "en", "/foolslide")
+class OneTimeScans : FoolSlide("One Time Scans", "https://reader.otscans.com", "en")
 
 class TsubasaSociety : FoolSlide("Tsubasa Society", "https://www.tsubasasociety.com", "en", "/reader/master/Xreader")
 


### PR DESCRIPTION
Fixes One Time Scans.

I'll also note that I checked all of Foolslide's sources today to see if any others were broken and found Shoujo Hearts, Shoujo Sense, and Storm In Heaven had issues.  Those issues are on their end and may be temporary so I'm not removing them in this PR.  I'll check on them again in the future and fix or remove as warranted.