### PR TITLE
MyReadingManga Thumbnail from API

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 25
+    extVersionCode = 26
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -9,4 +9,9 @@ ext {
     libVersion = '1.2'
 }
 
+dependencies {
+    compileOnly 'com.google.code.gson:gson:2.8.5'
+    compileOnly 'com.github.salomonbrys.kotson:kotson:2.5.0'
+}
+
 apply from: "$rootDir/common.gradle"

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -142,15 +142,16 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         val date = parseDate(document.select(".entry-time").text())
         val mangaUrl = document.baseUri()
         val chfirstname = document.select(".chapter-class a[href*=$mangaUrl]")?.first()?.text()?.ifEmpty { "Ch. 1" }?.capitalize() ?:"Ch. 1"
+        val scangroup= document.select(".entry-terms a[href*=group]")?.first()?.text()
         //create first chapter since its on main manga page
-        chapters.add(createChapter("1", document.baseUri(), date, chfirstname))
+        chapters.add(createChapter("1", document.baseUri(), date, chfirstname, scangroup))
         //see if there are multiple chapters or not
         document.select(chapterListSelector())?.let { it ->
             it.forEach {
                 if (!it.text().contains("Next »", true)) {
                     val pageNumber = it.text()
                     val chname = document.select(".chapter-class a[href$=/$pageNumber/]")?.text()?.ifEmpty { "Ch. $pageNumber" }?.capitalize() ?:"Ch. $pageNumber"
-                    chapters.add(createChapter(it.text(), document.baseUri(), date, chname))
+                    chapters.add(createChapter(it.text(), document.baseUri(), date, chname, scangroup))
                 }
             }
         }
@@ -163,11 +164,12 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
         return SimpleDateFormat("MMM dd, yyyy", Locale.US ).parse(date).time
     }
 
-    private fun createChapter(pageNumber: String, mangaUrl: String, date: Long, chname: String): SChapter {
+    private fun createChapter(pageNumber: String, mangaUrl: String, date: Long, chname: String, scangroup: String?): SChapter {
         val chapter = SChapter.create()
         chapter.setUrlWithoutDomain("$mangaUrl/$pageNumber")
         chapter.name = chname
         chapter.date_upload = date
+        chapter.scanlator = scangroup
         return chapter
     }
 

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -41,7 +41,7 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
     }
 
     override fun latestUpdatesRequest(page: Int) = popularMangaRequest(page)
-    
+
     override fun popularMangaParse(response: Response): MangasPage {
         val document = response.asJsoup()
         val mangas = mutableListOf<SManga>()
@@ -144,7 +144,6 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
             "Completed" -> SManga.COMPLETED
             else -> SManga.UNKNOWN
         }
-        // Set first image as thumbnail only if user has not entered from catalog section. 
         if (reststatus != null ) {} else {manga.thumbnail_url=thumbnailUrl} //Sets the thumbnail when logged in to API
         return manga
     }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -4,6 +4,7 @@ import com.github.salomonbrys.kotson.get
 import com.github.salomonbrys.kotson.nullObj
 import com.github.salomonbrys.kotson.obj
 import com.github.salomonbrys.kotson.string
+import com.google.gson.JsonParser
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -37,9 +37,11 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
 
     override fun latestUpdatesRequest(page: Int) = popularMangaRequest(page)
 
+    private var openbrowse : String? = null // Int a string to test if user opened "Browse" or not. 
+    
     override fun popularMangaParse(response: Response): MangasPage {
+        openbrowse = "true" // If parsing popular manga, usesr has entered catalogue browse
         val document = response.asJsoup()
-
         val mangas = mutableListOf<SManga>()
         val list  = document.select(popularMangaSelector()).filter { element ->
             val select = element.select("a[rel=bookmark]")
@@ -130,6 +132,8 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
             "Completed" -> SManga.COMPLETED
             else -> SManga.UNKNOWN
         }
+        // Set first image as thumbnail only if user has not entered from catalog section. 
+        if (openbrowse.isNullOrBlank()) manga.thumbnail_url =  document.select("img[data-lazy-src]:not([width='120']):not([data-original-width='300'])")?.first()?.attr("data-lazy-src")
         return manga
     }
 


### PR DESCRIPTION
2nd attempt to fix #1543 

Cover information is pulled from the wordpress API. User however must be logged in to the website for the API to return data. There is a very basic (possibly flawed) check to see if the user is logged in or not. 

Also included is a minor enhancement that adds the scanlator group to the chapter list.

Please feel free to point out how it can be optimized or flaws fixed. 