### PR TITLE
Fix MRM Filter IOException

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 26
+    extVersionCode = 27
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -9,6 +9,7 @@ import okhttp3.*
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import rx.Observable
+import java.io.IOException
 import java.net.URLEncoder
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -213,10 +214,10 @@ open class MyReadingManga(override val lang: String) : ParsedHttpSource() {
     override fun imageUrlParse(document: Document) = throw Exception("Not used")
 
     //Filter Parsing, grabs home page as document and filters out Genres, Popular Tags, and Catagorys
-    private val filterdoc = OkHttpClient().newCall(GET("$baseUrl", headers)).execute().asJsoup()
-    private val genresarray = filterdoc.select(".tagcloud a[href*=/genre/]").map { Pair(it.attr("href").substringBeforeLast("/").substringAfterLast("/"), it.text())}.toTypedArray()
-    private val poptagarray = filterdoc.select(".tagcloud a[href*=/tag/]").map { Pair(it.attr("href").substringBeforeLast("/").substringAfterLast("/"), it.text())}.toTypedArray()
-    private val cattagarray = filterdoc.select(".level-0").map { Pair(it.attr("value"), it.text())}.toTypedArray()
+    private val filterdoc:Document? = try { OkHttpClient().newCall(GET("$baseUrl", headers)).execute().asJsoup() } catch (e: IOException) {null}
+    private val genresarray = filterdoc?.select(".tagcloud a[href*=/genre/]")?.map { Pair(it.attr("href").substringBeforeLast("/").substringAfterLast("/"), it.text())}?.toTypedArray() ?: arrayOf(Pair("","Error getting filters, try restarting app"))
+    private val poptagarray = filterdoc?.select(".tagcloud a[href*=/tag/]")?.map { Pair(it.attr("href").substringBeforeLast("/").substringAfterLast("/"), it.text())}?.toTypedArray() ?: arrayOf(Pair("","Error getting filters, try restarting app"))
+    private val cattagarray = filterdoc?.select(".level-0")?.map { Pair(it.attr("value"), it.text())}?.toTypedArray() ?: arrayOf(Pair("","Error getting filters, try restarting app"))
     
     //Generates the filter lists for app
     override fun getFilterList(): FilterList {


### PR DESCRIPTION
Fixes #1557 

[Unhanded exception](https://kotlinlang.org/docs/reference/exceptions.html) [IOException from OKHTTPClient](https://square.github.io/okhttp/4.x/okhttp/okhttp3/-call/execute/) is now taken care of. 
Added some [null safety](https://kotlinlang.org/docs/reference/null-safety.html) for filters due to IOException

Tested online
Tested offline, did not crash on my phone. 