### PR TITLE
Hanhankuman Details Parse 

### DIFF
--- a/src/zh/hanhankuman/build.gradle
+++ b/src/zh/hanhankuman/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Hanhankuman'
     pkgNameSuffix = 'zh.hanhankuman'
     extClass = '.HanhanKuman'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/zh/hanhankuman/src/eu/kanade/tachiyomi/extension/zh/hanhankuman/HanhanKuman.kt
+++ b/src/zh/hanhankuman/src/eu/kanade/tachiyomi/extension/zh/hanhankuman/HanhanKuman.kt
@@ -78,8 +78,16 @@ class HanhanKuman : ParsedHttpSource() {
 
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
-//        manga.description = document.select("p.comic_deCon_d").text().trim()
-//        manga.thumbnail_url = document.select("div.comic_i_img > img").attr("src")
+        manga.author = document.select("li:contains(作者)").text()?.substringAfterLast(":")?.trim()
+        manga.artist = document.select("li:contains(作者)").text()?.substringAfterLast(":")?.trim()
+        manga.description = document.select("li:contains(简介)").text().substringAfterLast(":").trim()
+        manga.thumbnail_url = document.select("img[src*=comicui]").attr("src")
+        manga.status = when (document.select("li:contains(状态)").text()?.substringAfterLast(":")?.trim()) {
+            "连载" -> SManga.ONGOING
+            //"" -> SManga.COMPLETED
+            //"" -> SManga.LICENSED
+            else -> SManga.UNKNOWN
+        }
         return manga
     }
 

--- a/src/zh/hanhankuman/src/eu/kanade/tachiyomi/extension/zh/hanhankuman/HanhanKuman.kt
+++ b/src/zh/hanhankuman/src/eu/kanade/tachiyomi/extension/zh/hanhankuman/HanhanKuman.kt
@@ -84,7 +84,7 @@ class HanhanKuman : ParsedHttpSource() {
         manga.thumbnail_url = document.select("img[src*=comicui]").attr("src")
         manga.status = when (document.select("li:contains(状态)").text()?.substringAfterLast(":")?.trim()) {
             "连载" -> SManga.ONGOING
-            //"" -> SManga.COMPLETED
+            "完结" -> SManga.COMPLETED
             //"" -> SManga.LICENSED
             else -> SManga.UNKNOWN
         }


### PR DESCRIPTION
Fixes #1624 

Added back code in mangaDetailsParse which should fix the details and thumbnail on backup/restore as well as library update requests. 