### PR TITLE
Fixed manhuaren thumbnail error

### DIFF
--- a/src/zh/manhuaren/build.gradle
+++ b/src/zh/manhuaren/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Manhuaren'
     pkgNameSuffix = 'zh.manhuaren'
     extClass = '.Manhuaren'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 

--- a/src/zh/manhuaren/src/eu/kanade/tachiyomi/extension/zh/manhuaren/Manhuaren.kt
+++ b/src/zh/manhuaren/src/eu/kanade/tachiyomi/extension/zh/manhuaren/Manhuaren.kt
@@ -188,7 +188,7 @@ class Manhuaren : HttpSource() {
         obj.optString("mangaCoverimageUrl").let {
             if (it != "") { thumbnail_url = it }
         }
-        if (thumbnail_url == "") {
+        if (thumbnail_url == "" || thumbnail_url == "http://mhfm5.tel.cdndm5.com/tag/category/nopic.jpg") {
             obj.optString("mangaPicimageUrl").let {
                 if (it != "") { thumbnail_url = it }
             }


### PR DESCRIPTION
Some mangas' cover is replaced by default img, while the other optional img is available.
Here is a manga reponse example.
```
{
  "response": {
    "mangaName": "ANGEL PARA BELLUM",
    "mangaCoverimageUrl": "http://mhfm5.tel.cdndm5.com/tag/category/nopic.jpg",
    "mangaPicimageUrl": "http://mhfm4cnc.cdndm5.com/15/14963/14963_b.jpg",
}
```
![IMG_20191014_072754](https://user-images.githubusercontent.com/32921531/66724165-3af0c800-ee55-11e9-9b8f-a4df1b256048.jpg)