### PR TITLE
[Improvement] TuMangaOnline - Removed dups from latest updates

### DIFF
--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: TuMangaOnline'
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -22,10 +22,11 @@ class TuMangaOnline : ParsedHttpSource() {
 
     override val supportsLatest = true
 
-    private val rateLimitInterceptor = RateLimitInterceptor(4)
+    private val rateLimitInterceptor = RateLimitInterceptor(2)
 
     override val client: OkHttpClient = network.cloudflareClient.newBuilder()
-        .addNetworkInterceptor(rateLimitInterceptor).connectTimeout(1, TimeUnit.MINUTES)
+        .addNetworkInterceptor(rateLimitInterceptor)
+        .connectTimeout(1, TimeUnit.MINUTES)
         .readTimeout(1, TimeUnit.MINUTES)
         .retryOnConnectionFailure(true)
         .followRedirects(true)
@@ -67,6 +68,21 @@ class TuMangaOnline : ParsedHttpSource() {
             title = it.select("h4.text-truncate").text()
             thumbnail_url = it.select("style").toString().substringAfter("('").substringBeforeLast("')")
         }
+    }
+    
+     override fun latestUpdatesParse(response: Response): MangasPage {
+        val document = response.asJsoup()
+        val mangas = mutableListOf<SManga>()
+        val list = document.select(latestUpdatesSelector()).distinctBy { element ->
+            element.select("div.thumbnail-title > h4.text-truncate").text().trim()
+        }
+        for (element in list){
+            mangas.add(latestUpdatesFromElement(element))
+        }
+        val hasNextPage = latestUpdatesNextPageSelector().let { selector ->
+            document.select(selector).first()
+        } != null
+        return MangasPage(mangas, hasNextPage)
     }
 
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -72,13 +72,9 @@ class TuMangaOnline : ParsedHttpSource() {
     
      override fun latestUpdatesParse(response: Response): MangasPage {
         val document = response.asJsoup()
-        val mangas = mutableListOf<SManga>()
-        val list = document.select(latestUpdatesSelector()).distinctBy { element ->
-            element.select("div.thumbnail-title > h4.text-truncate").text().trim()
-        }
-        for (element in list){
-            mangas.add(latestUpdatesFromElement(element))
-        }
+        val mangas = document.select(latestUpdatesSelector())
+            .distinctBy { it.select("div.thumbnail-title > h4.text-truncate").text().trim() }
+            .map { latestUpdatesFromElement(it) }
         val hasNextPage = latestUpdatesNextPageSelector().let { selector ->
             document.select(selector).first()
         } != null


### PR DESCRIPTION
I wanted to fix the latest update bug first so I proposed the previous PR. However, all the duplicates bothered me so I wrote up a fix. It just took me a bit longer to code and validate. 

Fixes: Removes all the duplicate mangas due to how the site displays latest updates. 