### PR TITLE
[Feature] TuMangaOnline - Choose Scans

### DIFF
--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: TuMangaOnline'
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -191,7 +191,15 @@ class TuMangaOnline : ParsedHttpSource() {
         }
 
         // Regular list of chapters
-        return document.select(regularChapterListSelector()).map { regularChapterFromElement(it) }
+        val chapters = mutableListOf<SChapter>()
+        document.select(regularChapterListSelector()).forEach { chapelement ->
+            val chapternumber = chapelement.select("a.btn-collapse").text().substringBefore(":").substringAfter("Capítulo").trim().toFloat()
+            val chaptername = chapelement.select("div.col-10.text-truncate").text()
+            chapelement.select("ul.chapter-list > li").let { scanner ->
+                scanner.forEach { chapters.add(regularChapterFromElement(it, chaptername, chapternumber)) }
+                }
+        }
+        return chapters
     }
 
     override fun chapterListSelector() = throw UnsupportedOperationException("Not used")
@@ -208,9 +216,10 @@ class TuMangaOnline : ParsedHttpSource() {
 
     private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
 
-    private fun regularChapterFromElement(element: Element) = SChapter.create().apply {
+    private fun regularChapterFromElement(element: Element, chname: String, number: Float) = SChapter.create().apply {
         setUrlWithoutDomain(element.select("div.row > .text-right > a").attr("href"))
-        name = element.select("div.col-10.text-truncate").text()
+        name = chname
+        chapter_number = number
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
         date_upload = element.select("span.badge.badge-primary.p-2").first()?.text()?.let { parseChapterDate(it) } ?: 0
     }

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -195,9 +195,7 @@ class TuMangaOnline : ParsedHttpSource() {
         document.select(regularChapterListSelector()).forEach { chapelement ->
             val chapternumber = chapelement.select("a.btn-collapse").text().substringBefore(":").substringAfter("Capítulo").trim().toFloat()
             val chaptername = chapelement.select("div.col-10.text-truncate").text()
-            chapelement.select("ul.chapter-list > li").let { scanner ->
-                scanner.forEach { chapters.add(regularChapterFromElement(it, chaptername, chapternumber)) }
-                }
+            chapelement.select("ul.chapter-list > li").forEach { chapters.add(regularChapterFromElement(it, chaptername, chapternumber)) }
         }
         return chapters
     }


### PR DESCRIPTION
Closes #1671 

Old: Chapter elements were only selecting one scanner. 
New: Each chapters are now separated per scanner.
 
Notice for users: Chapter numbers are now added allowing for users to skip read chapters if sorted by "By chapter number"