### PR TITLE
[Mangadex] Remove eu/eu2 image server options and update strings to match current website options

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 69
+    extVersionCode = 70
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -584,8 +584,8 @@ abstract class Mangadex(
         val serverPref = ListPreference(screen.context).apply {
             key = SERVER_PREF_Title
             title = SERVER_PREF_Title
-            entries = arrayOf("Auto", "North America", "North America 2", "Europe", "Europe 2", "Rest of the World")
-            entryValues = arrayOf("0", "na", "na2", "eu", "eu2", "row")
+            entries = SERVER_PREF_ENTRIES
+            entryValues = SERVER_PREF_ENTRY_VALUES
             summary = "%s"
 
             setOnPreferenceChangeListener { _, newValue ->
@@ -603,7 +603,11 @@ abstract class Mangadex(
 
     private fun getShowR18(): Int = preferences.getInt(SHOW_R18_PREF, 0)
     private fun getShowThumbnail(): Int = preferences.getInt(SHOW_THUMBNAIL_PREF, 0)
-    private fun getServer(): String = preferences.getString(SERVER_PREF, "0")
+    private fun getServer(): String {
+        val default = SERVER_PREF_ENTRY_VALUES.first()
+        return preferences.getString(SERVER_PREF, default).takeIf { it in SERVER_PREF_ENTRY_VALUES }
+            ?: default
+    }
 
     private class TextField(name: String, val key: String) : Filter.Text(name)
     private class Tag(val id: String, name: String) : Filter.TriState(name)
@@ -765,6 +769,8 @@ abstract class Mangadex(
 
         private const val SERVER_PREF_Title = "Image server"
         private const val SERVER_PREF = "imageServer"
+        private val SERVER_PREF_ENTRIES = arrayOf("Automatic", "NA/EU 1", "NA/EU 2", "Rest of the world")
+        private val SERVER_PREF_ENTRY_VALUES = arrayOf("0", "na", "na2", "row")
 
         private const val API_MANGA = "/api/manga/"
         private const val API_CHAPTER = "/api/chapter/"


### PR DESCRIPTION
Confirmed by MD staff

```
[4:01 PM] FlaminSarge: quick q: the 'eu' and 'eu2' server query parameter options are completely gone and we should use 'na' and 'na2' only now, right?
[4:01 PM] FlaminSarge: or 'row'
[4:07 PM] Plykiya ⭐: @FlaminSarge eu isn't gone
[4:07 PM] Plykiya ⭐: the na and eu options are merged because Path automatically directs your traffic to their closest cache server which is either in the NA or EU
[4:37 PM] FlaminSarge: Sorry, right, the query param values only accept 'na' or 'na2' or 'row' now though, right?
[4:38 PM] FlaminSarge: last I checked, using 'eu' or 'eu2' values didn't work
[4:45 PM] Holo: yesw
[4:53 PM] FlaminSarge: ty
```