### PR TITLE
Fixed dmzj search error

### DIFF
--- a/src/zh/dmzj/build.gradle
+++ b/src/zh/dmzj/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Dmzj'
     pkgNameSuffix = 'zh.dmzj'
     extClass = '.Dmzj'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 

--- a/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
+++ b/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
@@ -45,7 +45,7 @@ class Dmzj : HttpSource() {
                 title = obj.getString("comic_name")
                 thumbnail_url = cleanUrl(obj.getString("comic_cover"))
                 author = obj.optString("comic_author")
-                url = "/comic/comic_$cid.json"
+                url = "/comic/comic_$cid.json?version=2.7.019"
             })
         }
         return MangasPage(ret, false)
@@ -67,7 +67,7 @@ class Dmzj : HttpSource() {
                     "连载中" -> SManga.ONGOING
                     else -> SManga.UNKNOWN
                 }
-                url = "/comic/comic_$cid.json"
+                url = "/comic/comic_$cid.json?version=2.7.019"
             })
         }
         return MangasPage(ret, arr.length() != 0)


### PR DESCRIPTION
The original comic query failed, and adding a version parameter will fix it.

Example:
 
❎[http://v3api.dmzj.com/comic/comic_47626.json](http://v3api.dmzj.com/comic/comic_47626.json)                             
✅[http://v3api.dmzj.com/comic/comic_47626.json?version=2.7.019](http://v3api.dmzj.com/comic/comic_47626.json?version=2.7.019)