### PR TITLE
[Enhancement] TuMangaOnline De-dup Preference

### DIFF
--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -5,12 +5,14 @@ ext {
     appName = 'Tachiyomi: TuMangaOnline'
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '1.2'
 }
 
 dependencies {
     implementation project(':lib-ratelimit')
+    compileOnly project(':preference-stub')
+    compileOnly 'com.github.inorichi.injekt:injekt-core:65b0440'
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Addresses https://github.com/inorichi/tachiyomi/issues/2297

New:
Provides preference option to remove duplicate chapter entries by only adding first scanlator on list. 

To be fixed later:
Strings are in English, someone should translate them properly. 
