### PR TITLE
[Fix] Mangafree - url with brackets

### DIFF
--- a/src/en/mangafree/build.gradle
+++ b/src/en/mangafree/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangafree'
     pkgNameSuffix = 'en.mangafree'
     extClass = '.Mangafree'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 

--- a/src/en/mangafree/src/eu/kanade/tachiyomi/extension/en/mangafree/Mangafree.kt
+++ b/src/en/mangafree/src/eu/kanade/tachiyomi/extension/en/mangafree/Mangafree.kt
@@ -135,7 +135,8 @@ class Mangafree : ParsedHttpSource() {
         val urlElement = element.select("a").first()
 
         val chapter = SChapter.create()
-        chapter.setUrlWithoutDomain(urlElement.attr("href"))
+        val url = urlElement.attr("href").replace("[","%255B").replace("]","%255D")
+        chapter.setUrlWithoutDomain(url)
         chapter.name = urlElement.text()
         return chapter
     }


### PR DESCRIPTION
Fixes #1704

~~Square brackets and some other characters are considered unsafe and really shouldn't be used ina url in general~~
Skimmed RFC 2396 for URI rules but didn't see anything particular. Either way, the URI parser is throwing an exception with square brackets so as a work around, we can pre-encode the brackets before sending it to setUrlWithoutDomain  