### PR TITLE
[Fix] Dmzj - api issues

### DIFF
--- a/src/zh/dmzj/build.gradle
+++ b/src/zh/dmzj/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Dmzj'
     pkgNameSuffix = 'zh.dmzj'
     extClass = '.Dmzj'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
+++ b/src/zh/dmzj/src/eu/kanade/tachiyomi/extension/zh/dmzj/Dmzj.kt
@@ -154,12 +154,15 @@ class Dmzj : HttpSource() {
                 ret.add(SChapter.create().apply {
                     name = "$prefix: ${chapter.getString("chapter_title")}"
                     date_upload = chapter.getString("updatetime").toLong()*1000 //milliseconds
-                    url = "/chapter/$cid/${chapter.getString("chapter_id")}.json"
+                    //V3API url = "/chapter/$cid/${chapter.getString("chapter_id")}.json"
+                    url = "http://m.dmzj.com/chapinfo/$cid/${chapter.getString("chapter_id")}.html" //From m_readerBg.js 
                 })
             }
         }
         return ret
     }
+    
+    override fun pageListRequest(chapter: SChapter) = GET( chapter.url, headers) //Bypass base url
 
     override fun pageListParse(response: Response): List<Page> {
         val obj = JSONObject(response.body()!!.string())


### PR DESCRIPTION
Fixes #1702 

The V3 API for Dmzj is reporting back "章节不存在" (Chapter does not exist)

I'm not sure how the api works. I'm also not sure if the api is having temporary issues or not. 

The javascript to load the chapters refers to `var request_chap_url = '/chapinfo/' + this.comic_id + '/' + this.chapter_id + '.html';` which is working more reliably and looks to return the same json file currently so I updated the page list request. 