### PR TITLE
[Fix] Mangakakalot Redirect

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
@@ -58,7 +58,7 @@ abstract class MangaBox (
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
         element.select("h3 a").first().let {
-            manga.setUrlWithoutDomain(it.attr("abs:href"))
+            manga.url = it.attr("abs:href").substringAfter(baseUrl) // intentionally not using setUrlWithoutDomain
             manga.title = it.text()
         }
         manga.thumbnail_url = element.select("img").first().attr("abs:src")


### PR DESCRIPTION
I think 7 of the 12 "latest" manga on mangakakalot is redirected to manganelo. 

This should set the manga url the same way as the chapter urls are set. 