### PR TITLE
[Fix] Kuaikanmanhua - locked chapters

### DIFF
--- a/src/zh/kuaikanmanhua/build.gradle
+++ b/src/zh/kuaikanmanhua/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Kuaikanmanhua'
     pkgNameSuffix = 'zh.kuaikanmanhua'
     extClass = '.Kuaikanmanhua'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/Kuaikanmanhua.kt
+++ b/src/zh/kuaikanmanhua/src/eu/kanade/tachiyomi/extension/zh/kuaikanmanhua/Kuaikanmanhua.kt
@@ -155,10 +155,17 @@ class Kuaikanmanhua : ParsedHttpSource() {
         val chapter = SChapter.create()
 
         element.select("div.title a").let {
-            chapter.setUrlWithoutDomain(it.attr("href"))
-            chapter.name = it.text()
+            chapter.url = it.attr("href")
+            chapter.name = it.text() + if (element.select("i.lockedIcon").isNotEmpty()) {" \uD83D\uDD12"} else {""}
         }
         return chapter
+    }
+
+    override fun pageListRequest(chapter: SChapter): Request {
+        if (chapter.url=="javascript:void(0);") {
+            return throw Exception("[此章节为付费内容]")
+        }
+        return super.pageListRequest(chapter)
     }
 
     override fun pageListParse(document: Document): List<Page> {


### PR DESCRIPTION
Closes #1729 

Chapters links are currently a relative link so I removed setUrlWithoutDomain
I added a lock icon for locked chapters as well as a exception toast. 

Thank you @SnakeDoc83 for helping take a look too. 