### PR TITLE
MangaDex - group search

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 70
+    extVersionCode = 71
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Adds ability to find all the manga from a group.  It works when you're not logged in too; so it's another way to find manga besides using ID (assuming you know which group TLed it).