### PR TITLE
[Fix] Mangabox - balanced marker at status

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 

--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
@@ -137,7 +137,7 @@ abstract class MangaBox (
 
         manga.title = infoElement.select("h1, h2").first().text()
         manga.author = infoElement.select("li:contains(author) a").text()
-        val status = infoElement.select("li:contains(status").text()
+        val status = infoElement.select("li:contains(status)").text()
         manga.status = parseStatus(status)
         manga.genre = infoElement.select("div.manga-info-top li:contains(genres)").text().substringAfter(": ")
         manga.description = document.select(descriptionSelector).first().ownText()


### PR DESCRIPTION
I'm not sure why mainline Tachi wasn't complaining and Tachi-EH did but here is the fix for `Did not find balanced marker at 'status'` when using mangabox in Tach-EH