### PR TITLE
[Change] Mangamx

### DIFF
--- a/src/es/mangamx/build.gradle
+++ b/src/es/mangamx/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaMx'
     pkgNameSuffix = 'es.mangamx'
     extClass = '.MangaMx'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
#1756 

Changed Latest Updates from 'Latest Manga added to the site' to 'Latest Chapters added to the site'
Extension tries to remove duplicates but it only works per page. 

Still to do: genre filtering but I still need to learn a bit more on how the filters work and how to properly add them in. 