### PR TITLE
[Ready] TMO Update

### DIFF
--- a/src/es/tumangaonline/build.gradle
+++ b/src/es/tumangaonline/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: TuMangaOnline'
     pkgNameSuffix = 'es.tumangaonline'
     extClass = '.TuMangaOnline'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '1.2'
 }
 

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -275,7 +275,6 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             .build()
 
         val url = getBuilder(goto,getHeaders,formBody).substringBeforeLast("/") + "/cascade"
-        Log.i("TachiDebug", "Viewer URL => $url")
         // Get /cascade instead of /paginate to get all pages at once
 
         val headers = headersBuilder()

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -232,7 +232,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun oneShotChapterListSelector() = "div.chapter-list-element > ul.list-group li.list-group-item"
 
     private fun oneShotChapterFromElement(element: Element, token: String, chapteridselector: String, hashselector: String) = SChapter.create().apply {
-        val button = element.select("div.row > .text-right > button")
+        val button = element.select("div.row > .text-right > span")
         url = button.attr(chapteridselector) + "&" + button.attr(hashselector) + "&" + token
         name = "One Shot"
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
@@ -242,7 +242,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
 
     private fun regularChapterFromElement(element: Element, chname: String, number: Float, token: String, chapteridselector: String, hashselector: String) = SChapter.create().apply {
-        val button = element.select("div.row > .text-right > button")
+        val button = element.select("div.row > .text-right > span")
         url = button.attr(chapteridselector) + "&" + button.attr(hashselector) + "&" + token
         name = chname
         chapter_number = number
@@ -254,7 +254,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
     override fun pageListRequest(chapter: SChapter): Request {
         val (chapterid, hash, token) = chapter.url.split("&")
-        val goto = "$baseUrl/goto/$chapterid/$hash"
+        val goto = "$baseUrl/goto/$hash/$chapterid"
         val formBody = FormBody.Builder()
             .add("_token", token)
             .build()

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -253,20 +253,14 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
     override fun pageListRequest(chapter: SChapter): Request {
         val (chapterURL, chapterID) = chapter.url.split("#")
-
         val response = client.newCall(GET(chapterURL, headers)).execute()
         val document = response.asJsoup()
-
         val csrfToken = document.select("meta[name=csrf-token]").attr("content")
-
         val script = document.select("script:containsData($scriptselector)").html()
         val functionID = script.substringAfter("addEventListener").substringAfter("{").substringBefore("(").trim().removePrefix("_")
         val function = script.substringAfter("function _$functionID(").substringBefore("});")
         val goto = function.substringAfter("url: '").substringBefore("'")
-
         val paramChapter = function.substringAfter("data").substringBefore("\":_").substringAfterLast("\"")
-        val paramManga = function.substringAfter("data").substringBefore("\": ").substringAfterLast("\"")
-        //val mangaID = function.substringAfter("data").substringAfter("\": ").substringBefore(",").removeSurrounding("'")
 
         val getHeaders = headersBuilder()
             .add("User-Agent", userAgent)
@@ -277,19 +271,11 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             .add(functionID,functionID)
             .build()
 
-        fun formBody():FormBody {
-            val formBody = FormBody.Builder()
-            if (function.substringAfter("data").substringBefore(",").contains("getAttribute")) {
-                formBody.add(paramChapter, chapterID)
-                    //.add(paramManga, mangaID)
-            } else {
-                formBody//.add(paramManga, mangaID)
-                    .add(paramChapter, chapterID)
-            }
-            return formBody.build()
-        }
+        val formBody = FormBody.Builder()
+            .add(paramChapter, chapterID)
+            .build()
 
-        val url = getBuilder(goto,getHeaders,formBody()).substringBeforeLast("/") + "/cascade"
+        val url = getBuilder(goto,getHeaders,formBody).substringBeforeLast("/") + "/cascade"
         // Get /cascade instead of /paginate to get all pages at once
 
         val headers = headersBuilder()

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -257,7 +257,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
         val csrfToken = document.select("meta[name=csrf-token]").attr("content")
         val script = document.select("script:containsData($scriptselector)").html()
         val functionID = script.substringAfter("addEventListener").substringAfter("{").substringBefore("(").trim().removePrefix("_")
-        val function = script.substringAfter("function _$functionID(").substringBefore("function _")//.substringBefore("});")
+        val function = script.substringAfter("function _$functionID(").substringBefore("function _")
         val goto = function.substringAfter("url: '").substringBefore("'")
         val paramChapter = function.substringAfter("data").substringAfter("\"").substringBefore("\"")
         val paramManga = function.substringBefore("success").substringBeforeLast("\"").substringAfterLast("\"")

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -228,7 +228,6 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun oneShotChapterListSelector() = "div.chapter-list-element > ul.list-group li.list-group-item"
 
     private fun oneShotChapterFromElement(element: Element, token: String) = SChapter.create().apply {
-        //setUrlWithoutDomain(element.select("div.row > .text-right > a").attr("href"))
         url = element.select("div.row > .text-right > button").attr("onclick").substringAfter("'").substringBefore("'") + "&" + token
         name = "One Shot"
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
@@ -238,7 +237,6 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
 
     private fun regularChapterFromElement(element: Element, chname: String, number: Float, token: String) = SChapter.create().apply {
-        //setUrlWithoutDomain(element.select("div.row > .text-right > a").attr("href"))
         url = element.select("div.row > .text-right > button").attr("onclick").substringAfter("'").substringBefore("'") + "&" + token
         name = chname
         chapter_number = number
@@ -266,34 +264,11 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             .url()
             .toString()
             .substringBeforeLast("/") + "/cascade"
-        //val url = getBuilder(baseUrl + chapter.url).substringBeforeLast("/") + "/cascade"
-        //val test = throw Exception(url)
+
         // Get /cascade instead of /paginate to get all pages at once
         return GET(url, headers)
     }
-/*
-    override fun pageListParse(response: Response): List<Page> {
-        val body = response.asJsoup()
-            val imageRoute = body.select("script:containsData(imageRoute)").html().substringAfter("imageRoute = \"").substringBefore(":IMAGE_NAME")
-        val token = body.select("meta[name=csrf-token]").attr("content")
-        val base64 = body.select("script:containsData(base64)").html().substringAfter("','").substringBefore("','all');")
-        val chapterid = body.baseUri().substringAfter("viewer/").substringBefore("/cascade")
-        val headers = headersBuilder()
-            .add("Content-Type", "application/json; charset=utf-8")
-            .add("X-CSRF-TOKEN",token)
-            .build()
-        val jsonData = client.newCall(POST("$baseUrl/upload_images/$chapterid/$base64/all", headers)).execute()
-        val jbody = jsonData.body()!!.string()
-        //throw Exception(jbody)
-        val results = JsonParser().parse(jbody).asJsonArray
-        val pages = mutableListOf<Page>()
-        for (i in 0 until results.size()) {
-            pages.add(Page(i, "",imageRoute + results[i].string))
-        }
-        return pages
-    }
-    */
-//*
+
     override fun pageListParse(response: Response): List<Page> = mutableListOf<Page>().apply {
         val body = response.asJsoup()
 
@@ -301,7 +276,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             add(Page(size, "", it.attr("src")))
         }
     }
-//*/
+
     override fun pageListParse(document: Document) = throw UnsupportedOperationException("Not used")
 
     override fun imageUrlRequest(page: Page) = GET(page.url, headers)

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -199,7 +199,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
-        
+
         // One-shot
         if (document.select("div.chapters").isEmpty()) {
             return document.select(oneShotChapterListSelector()).map { oneShotChapterFromElement(it) }
@@ -228,7 +228,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun oneShotChapterListSelector() = "div.chapter-list-element > ul.list-group li.list-group-item"
 
     private fun oneShotChapterFromElement(element: Element) = SChapter.create().apply {
-        url = element.select("div.row > .text-right > button").attr("onclick").substringAfter("('").substringBefore("')")
+        url = element.select("div.row > .text-right > button").attr("onclick")
         name = "One Shot"
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
         date_upload = element.select("span.badge.badge-primary.p-2").first()?.text()?.let { parseChapterDate(it) } ?: 0
@@ -237,7 +237,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
 
     private fun regularChapterFromElement(element: Element, chname: String, number: Float) = SChapter.create().apply {
-        url = element.select("div.row > .text-right > button").attr("onclick").substringAfter("('").substringBefore("')")
+        url = element.select("div.row > .text-right > button").attr("onclick")
         name = chname
         chapter_number = number
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
@@ -247,7 +247,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun parseChapterDate(date: String): Long = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(date).time
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val (chapterid, hash, token) = chapter.url.split("','")
+        val (chapterid, hash, token) = chapter.url.substringAfter("('").substringBefore("')").split("','")
         val goto = "$baseUrl/goto/$chapterid/$hash"
         val formBody = FormBody.Builder()
             .add("_token", token)

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -264,7 +264,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
         val paramChapter = function.substringAfter("data").substringBefore("\":_").substringAfterLast("\"")
         val paramManga = function.substringAfter("data").substringBefore("\": ").substringAfterLast("\"")
-        val mangaID = function.substringAfter("data").substringAfter("\": ").substringBefore(",").removeSurrounding("'")
+        //val mangaID = function.substringAfter("data").substringAfter("\": ").substringBefore(",").removeSurrounding("'")
 
         val getHeaders = headersBuilder()
             .add("Referer", chapterURL)
@@ -277,9 +277,9 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             val formBody = FormBody.Builder()
             if (function.substringAfter("data").substringBefore(",").contains("getAttribute")) {
                 formBody.add(paramChapter, chapterID)
-                    .add(paramManga, mangaID)
+                    //.add(paramManga, mangaID)
             } else {
-                formBody.add(paramManga, mangaID)
+                formBody//.add(paramManga, mangaID)
                     .add(paramChapter, chapterID)
             }
             return formBody.build()

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -251,7 +251,6 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
     override fun pageListRequest(chapter: SChapter): Request {
         val (chapterURL, chapterID) = chapter.url.split("#")
-        val mangaID = chapterURL.substringAfter("library/").substringAfter("/").substringBefore("/")
 
         val response = client.newCall(GET(chapterURL, headers)).execute()
         val document = response.asJsoup()
@@ -262,8 +261,10 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
         val functionID = script.substringAfter("addEventListener").substringAfter("{").substringBefore("(").trim().removePrefix("_")
         val function = script.substringAfter("function _$functionID(").substringBefore("});")
         val goto = function.substringAfter("url: '").substringBefore("'")
+
         val paramChapter = function.substringAfter("data").substringBefore("\":_").substringAfterLast("\"")
         val paramManga = function.substringAfter("data").substringBefore("\": ").substringAfterLast("\"")
+        val mangaID = function.substringAfter("data").substringAfter("\": ").substringBefore(",").removeSurrounding("'")
 
         val getHeaders = headersBuilder()
             .add("Referer", chapterURL)
@@ -272,12 +273,19 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             .add(functionID,functionID)
             .build()
 
-        val formBody = FormBody.Builder()
-            .add(paramManga,mangaID)
-            .add(paramChapter,chapterID)
-            .build()
+        fun formBody():FormBody {
+            val formBody = FormBody.Builder()
+            if (function.substringAfter("data").substringBefore(",").contains("getAttribute")) {
+                formBody.add(paramChapter, chapterID)
+                    .add(paramManga, mangaID)
+            } else {
+                formBody.add(paramManga, mangaID)
+                    .add(paramChapter, chapterID)
+            }
+            return formBody.build()
+        }
 
-        val url = getBuilder(goto,getHeaders,formBody).substringBeforeLast("/") + "/cascade"
+        val url = getBuilder(goto,getHeaders,formBody()).substringBeforeLast("/") + "/cascade"
         // Get /cascade instead of /paginate to get all pages at once
 
         val headers = headersBuilder()

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -255,7 +255,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
         val document = response.asJsoup()
 
         val csrftoken = document.select("meta[name=csrf-token]").attr("content")
-        val csjftoken = document.select("meta[name=csjf-token]").attr("content")
+        //val csjftoken = document.select("meta[name=csjf-token]").attr("content")
 
         val script = document.select("script:containsData($scriptselector)").html()
         val chapteridselector = script.substringAfter("getAttribute(\"").substringBefore("\"")
@@ -268,7 +268,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             .add("Referer", chapterurl)
             .add("Content-Type","application/x-www-form-urlencoded; charset=UTF-8")
             .add("X-CSRF-TOKEN",csrftoken)
-            .add("X-CSJF-TOKEN",csjftoken)
+            //.add("X-CSJF-TOKEN",csjftoken)
             .build()
 
         val formBody = FormBody.Builder()

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -200,13 +200,15 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     override fun chapterListParse(response: Response): List<SChapter> {
         val document = response.asJsoup()
         val token = document.select("meta[name=csrf-token]").attr("content")
-        val script = document.select("script:containsData(url_goto)").html()
-        val chapteridselector = script.substringAfter("GO_TO_ID\", elem.getAttribute(\"").substringBefore("\"")
-        val hashselector = script.substringAfter("HASH\", elem.getAttribute(\"").substringBefore("\"")
-
+        val script = document.select("script:containsData(redirect)").html()
+        val chapteridselector = script.substringAfter("getAttribute(\"").substringBefore("\"")
+        val url_goto = script.substringAfter("action\", '$baseUrl/").substringBefore("/:")
+        val rice = script.substringAfter("\"rice\"").substringAfter("\"value\",'").substringBefore("'")
+        val rice2 = script.substringAfter("\"rice2\"").substringAfter("value\",").substringBefore(")")
+       
         // One-shot
         if (document.select("div.chapters").isEmpty()) {
-            return document.select(oneShotChapterListSelector()).map { oneShotChapterFromElement(it, token, chapteridselector, hashselector) }
+            return document.select(oneShotChapterListSelector()).map { oneShotChapterFromElement(it, token, rice, rice2, url_goto, chapteridselector) }
         }
 
         // Regular list of chapters
@@ -217,10 +219,10 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
             val scanelement = chapelement.select("ul.chapter-list > li")
             val dupselect = getduppref()!!
             if (dupselect=="one") {
-                scanelement.first { chapters.add(regularChapterFromElement(it, chaptername, chapternumber, token, chapteridselector, hashselector)) }
+                scanelement.first { chapters.add(regularChapterFromElement(it, chaptername, chapternumber, token, rice, rice2, url_goto, chapteridselector)) }
             }
             else {
-                scanelement.forEach { chapters.add(regularChapterFromElement(it, chaptername, chapternumber, token, chapteridselector, hashselector)) }
+                scanelement.forEach { chapters.add(regularChapterFromElement(it, chaptername, chapternumber, token, rice, rice2, url_goto, chapteridselector)) }
             }
         }
         return chapters
@@ -231,9 +233,9 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
     private fun oneShotChapterListSelector() = "div.chapter-list-element > ul.list-group li.list-group-item"
 
-    private fun oneShotChapterFromElement(element: Element, token: String, chapteridselector: String, hashselector: String) = SChapter.create().apply {
+    private fun oneShotChapterFromElement(element: Element, token: String, rice: String, rice2: String, url_goto: String, chapteridselector: String) = SChapter.create().apply {
         val button = element.select("div.row > .text-right > span")
-        url = button.attr(chapteridselector) + "&" + button.attr(hashselector) + "&" + token
+        url = "$baseUrl/$url_goto/${button.attr(chapteridselector)}/redirect&$token&$rice&$rice2"
         name = "One Shot"
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
         date_upload = element.select("span.badge.badge-primary.p-2").first()?.text()?.let { parseChapterDate(it) } ?: 0
@@ -241,9 +243,9 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
 
     private fun regularChapterListSelector() = "div.chapters > ul.list-group li.p-0.list-group-item"
 
-    private fun regularChapterFromElement(element: Element, chname: String, number: Float, token: String, chapteridselector: String, hashselector: String) = SChapter.create().apply {
+    private fun regularChapterFromElement(element: Element, chname: String, number: Float, token: String, rice: String, rice2: String, url_goto: String, chapteridselector: String) = SChapter.create().apply {
         val button = element.select("div.row > .text-right > span")
-        url = button.attr(chapteridselector) + "&" + button.attr(hashselector) + "&" + token
+        url = "$baseUrl/$url_goto/${button.attr(chapteridselector)}/redirect&$token&$rice&$rice2"
         name = chname
         chapter_number = number
         scanlator = element.select("div.col-md-6.text-truncate")?.text()
@@ -253,10 +255,11 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
     private fun parseChapterDate(date: String): Long = SimpleDateFormat("yyyy-MM-dd", Locale.getDefault()).parse(date).time
 
     override fun pageListRequest(chapter: SChapter): Request {
-        val (chapterid, hash, token) = chapter.url.split("&")
-        val goto = "$baseUrl/goto/$hash/$chapterid"
+        val (goto, token, rice, rice2) = chapter.url.split("&")
         val formBody = FormBody.Builder()
             .add("_token", token)
+            .add("rice", rice)
+            .add("rice2", rice2)
             .build()
         val url = getBuilder(goto,formBody).substringBeforeLast("/") + "/cascade"
         // Get /cascade instead of /paginate to get all pages at once

--- a/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
+++ b/src/es/tumangaonline/src/eu/kanade/tachiyomi/extension/es/tumangaonline/TuMangaOnline.kt
@@ -38,10 +38,12 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
         .retryOnConnectionFailure(true)
         .followRedirects(true)
         .build()!!
+    
+    private val userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:71.0) Gecko/20100101 Firefox/71.0"
 
     override fun headersBuilder(): Headers.Builder {
         return Headers.Builder()
-            .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36")
+            .add("User-Agent", userAgent)
             .add("Referer", "$baseUrl/")
             .add("Cache-mode", "no-cache")
     }
@@ -267,9 +269,11 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
         //val mangaID = function.substringAfter("data").substringAfter("\": ").substringBefore(",").removeSurrounding("'")
 
         val getHeaders = headersBuilder()
+            .add("User-Agent", userAgent)
             .add("Referer", chapterURL)
             .add("Content-Type","application/x-www-form-urlencoded; charset=UTF-8")
             .add("X-CSRF-TOKEN",csrfToken)
+            .add("X-Requested-With","XMLHttpRequest")
             .add(functionID,functionID)
             .build()
 
@@ -289,7 +293,7 @@ class TuMangaOnline : ConfigurableSource, ParsedHttpSource() {
         // Get /cascade instead of /paginate to get all pages at once
 
         val headers = headersBuilder()
-            .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/78.0.3904.108 Safari/537.36")
+            .add("User-Agent", userAgent)
             .add("Referer", chapterURL)
             .build()
 


### PR DESCRIPTION
This PR should be ready to pull pending any further changes from TMO. It has been a few days since their last (daily) change. We can still wait some more to see if anything changes... again. 

This should fix #1749

Current revisions:

- Revert pageListParse
- Chapter URL are no longer directly linked from manga page. Read button is an actual button with a scripted click action. This now pulls the chapter ID and requests viewer url via POST.

FAQ Reminder that needs to be posted: 
Since chapter URLs have been updated, the chapter lists in the library need to be pulled to refresh.