### PR TITLE
[Fix v2] AllPornComics

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 27
+    extVersionCode = 28
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -226,6 +226,7 @@ class GetManhwa : Madara("GetManhwa", "https://getmanhwa.co", "en") {
 }
 class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
+        .add("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:70.0) Gecko/20100101 Firefox/70.0")
     override fun searchMangaNextPageSelector() = "a[rel=next]"
     override fun getGenreList() = listOf(
         Genre("3D", "3d"),


### PR DESCRIPTION
Second time to try to fix #1769

Error 503 + cloudflare server is assumed to be ddos protectoin with check.
Turns out, site is also running wordfence security (found out when I got temp banned). Possible with rate limiting. Turns out, wordfence also throws 503 errors which causes the cloudflare client to check for challenge url which doesn't exist. 

Added desktop user-agent to bypass the 503 since the website loads for my desktop browser. It was part of my testing the first time but it was working without it too so I got rid of it in my previous PR. 
