### PR TITLE
Madara Fixes, - revert AllPornComics, ZinManga fix

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 27
+    extVersionCode = 28
     libVersion = '1.2'
 }
 

--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 28
+    extVersionCode = 29
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -226,6 +226,7 @@ class GetManhwa : Madara("GetManhwa", "https://getmanhwa.co", "en") {
 }
 class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
+        .add("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:70.0) Gecko/20100101 Firefox/70.0")
     override fun searchMangaNextPageSelector() = "a[rel=next]"
     override fun getGenreList() = listOf(
         Genre("3D", "3d"),

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -8,12 +8,9 @@ import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.Headers
-import okhttp3.HttpUrl
-import okhttp3.Request
-import okhttp3.Response
+import okhttp3.*
 import java.text.SimpleDateFormat
-import java.util.Locale
+import java.util.*
 
 class MadaraFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
@@ -225,8 +222,12 @@ class GetManhwa : Madara("GetManhwa", "https://getmanhwa.co", "en") {
     override fun searchMangaNextPageSelector() = "nav.navigation-ajax"
 }
 class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
+    private val time = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
+    override val client: OkHttpClient = network.client
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:70.0) Gecko/20100101 Firefox/70.0")
+        .add("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:70.0) Gecko/20100101 Firefox/70.0 $time")
+    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=views", headers)
+    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=latest", headers)
     override fun searchMangaNextPageSelector() = "a[rel=next]"
     override fun getGenreList() = listOf(
         Genre("3D", "3d"),

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -199,7 +199,7 @@ class ChibiManga : Madara("Chibi Manga", "http://www.cmreader.info/", "en") {
 }
 
 class ZinManga : Madara("Zin Translator", "https://zinmanga.com/", "en") {
-    override fun headersBuilder(): Headers.Builder = Headers.Builder()
+    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .add("Referer", "https://zinmanga.com/")
     override fun searchMangaNextPageSelector() = "nav.navigation-ajax"
 }
@@ -228,6 +228,7 @@ class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
     override val client: OkHttpClient = network.client
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:70.0) Gecko/20100101 Firefox/70.0 $time")
+        .add("Referer", "https://allporncomic.com/")
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=views", headers)
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=latest", headers)
     override fun searchMangaNextPageSelector() = "a[rel=next]"

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -199,6 +199,8 @@ class ChibiManga : Madara("Chibi Manga", "http://www.cmreader.info/", "en") {
 }
 
 class ZinManga : Madara("Zin Translator", "https://zinmanga.com/", "en") {
+    override fun headersBuilder(): Headers.Builder = Headers.Builder()
+        .add("Referer", "https://zinmanga.com/")
     override fun searchMangaNextPageSelector() = "nav.navigation-ajax"
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -224,13 +224,6 @@ class GetManhwa : Madara("GetManhwa", "https://getmanhwa.co", "en") {
     override fun searchMangaNextPageSelector() = "nav.navigation-ajax"
 }
 class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
-    private val time = SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(Date())
-    override val client: OkHttpClient = network.client
-    override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("User-Agent","Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:70.0) Gecko/20100101 Firefox/70.0 $time")
-        .add("Referer", "https://allporncomic.com/")
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=views", headers)
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=latest", headers)
     override fun searchMangaNextPageSelector() = "a[rel=next]"
     override fun getGenreList() = listOf(
         Genre("3D", "3d"),


### PR DESCRIPTION
**ZinManga** https://github.com/inorichi/tachiyomi/issues/2335
Added Referrer to resolve 403 forbidden from images hosted by CDN

**AllPornComics** https://github.com/inorichi/tachiyomi-extensions/issues/1769
503 errors should have come from WordFence. However, due to also running though the cloudflare cdn, it triggered Tachiyomi's cloudflare bypass. Wordfence seems to be behaving now so, I reverted the changes. 

Draft pending continued testing against AllPornComics to ensure the fix actually sticks. 