### PR TITLE
[Fix] Mangahere - Parser for webtoon type 

### DIFF
--- a/src/en/mangahere/build.gradle
+++ b/src/en/mangahere/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangahere'
     pkgNameSuffix = 'en.mangahere'
     extClass = '.Mangahere'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '1.2'
 }
 

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -197,7 +197,7 @@ class Mangahere : ParsedHttpSource() {
             val script = document.select("script:containsData(function(p,a,c,k,e,d))").html().removePrefix("eval")
             val duktape = Duktape.create()
             val DeobfuscatedScript = duktape.evaluate(script).toString()
-            val urls = DeobfuscatedScript.substringAfter("newImgs=['").substringBefore("];").split("','")
+            val urls = DeobfuscatedScript.substringAfter("newImgs=['").substringBefore("'];").split("','")
             duktape.close()
             val pages = mutableListOf<Page>()
             urls.forEachIndexed { index, s ->

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -192,6 +192,19 @@ class Mangahere : ParsedHttpSource() {
     }
 
     override fun pageListParse(document: Document): List<Page> {
+        val bar = document.select("script[src*=chapter_bar]")
+        if (!bar.isNullOrEmpty()){
+            val script = document.select("script:containsData(function(p,a,c,k,e,d))").html().removePrefix("eval")
+            val duktape = Duktape.create()
+            val DeobfuscatedScript = duktape.evaluate(script).toString()
+            val urls = DeobfuscatedScript.substringAfter("newImgs=['").substringBefore("];").split("','")
+            duktape.close()
+            val pages = mutableListOf<Page>()
+            urls.forEachIndexed { index, s ->
+                pages.add(Page(index, "", "http:$s"))
+            }
+            return pages
+        } else {
 
         val html = document.html()
         val link = document.location()
@@ -259,6 +272,7 @@ class Mangahere : ParsedHttpSource() {
         duktape.close()
 
         return pages
+        }
     }
 
     private fun extractSecretKey(html: String, duktape: Duktape): String {


### PR DESCRIPTION
Fixes #1808 

Checks if page is using webtoon viewer (ie chapter_bar.js)
Then de-obfuscates the script and pulls in url data.