### PR TITLE
[Fix] Manhuadui

### DIFF
--- a/src/zh/manhuadui/build.gradle
+++ b/src/zh/manhuadui/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Manhuadui'
     pkgNameSuffix = 'zh.manhuadui'
     extClass = '.Manhuadui'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 

--- a/src/zh/manhuadui/src/eu/kanade/tachiyomi/extension/zh/manhuadui/Manhuadui.kt
+++ b/src/zh/manhuadui/src/eu/kanade/tachiyomi/extension/zh/manhuadui/Manhuadui.kt
@@ -1,7 +1,5 @@
 package eu.kanade.tachiyomi.extension.zh.manhuadui
 
-//import android.util.Base64.NO_WRAP
-//import java.util.*
 import android.util.Base64
 import com.squareup.duktape.Duktape
 import eu.kanade.tachiyomi.network.GET
@@ -15,10 +13,6 @@ import org.jsoup.nodes.Element
 import javax.crypto.Cipher
 import javax.crypto.spec.IvParameterSpec
 import javax.crypto.spec.SecretKeySpec
-
-//import android.util.Base64
-//import android.util.Log
-
 
 class Manhuadui : ParsedHttpSource() {
 
@@ -153,8 +147,12 @@ class Manhuadui : ParsedHttpSource() {
             it.evaluate(imgCode!! + """.join('|')""") as String
         }
         return imgArrStr.split('|').mapIndexed { i, imgStr ->
-            //Log.i("test", "img => ${imageServer[0]}/$imgPath$imgStr")
-            Page(i, "", if (imgStr.indexOf("http") == -1) "${imageServer[0]}/$imgPath$imgStr" else imgStr)
+            //Log.i("Tachidebug", "img => ${imageServer[0]}/$imgPath$imgStr")
+            if (imgStr.startsWith("http://images.dmzj.com")) {
+                Page(i, "", "https://mhcdn.manhuazj.com/showImage.php?url=$imgStr")
+            } else {
+                Page(i, "", if (imgStr.indexOf("http") == -1) "${imageServer[0]}/$imgPath$imgStr" else imgStr)
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #1836

Image failed because it was forbidden to hot link direct to `images.dmzj.com` server. 
Loads image though `https://mhcdn.manhuazj.com/showImage.php?url=` which is how the website normally works. 