### PR TITLE
[Patch] MangaBox - Change CDN 

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 

--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
@@ -218,10 +218,19 @@ abstract class MangaBox (
         val pages = mutableListOf<Page>()
 
         document.select(pageListSelector).forEach {
-            pages.add(Page(pages.size, "", it.attr("abs:src")))
+            pages.add(Page(pages.size, "", changecdn(it.attr("abs:src"))))
         }
 
         return pages
+    }
+    
+    private fun changecdn(url: String): String {
+        if (url.startsWith("https://convert_image_digi.mgicdn.com")) {
+            val newurl = "https://images.weserv.nl/?url=" + url.removePrefix("https://")
+            return newurl
+        } else {
+            return url
+        }
     }
 
     override fun imageUrlParse(document: Document): String = throw  UnsupportedOperationException("No used")


### PR DESCRIPTION
Fixes #1844 

I hit an issue with the `convert_image_digi.mgicdn.com` on 10/13/2019 where tachi will not load the image correctly. I still can't tell what exactly is the problem is. A site such as Mangakakalot is referencing the `mgicdn.com` which in turn pulled from the `mrcdn.info` (manga rock?)

Because it will not load correctly from `convert_image_digi.mgicdn.com`, this attempts to remedy it by passing it to the `Images.weserv.nl` image cache which will work.

I'm not sure if it is a good idea or not but it does work.   