### PR TITLE
Move Toonily into Madara

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 35
+    extVersionCode = 36
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -60,7 +60,8 @@ class MadaraFactory : SourceFactory {
         Azora(),
         HunterFansub(),
         MangaArabTeam(),
-        NightComic()
+        NightComic(),
+        Toonily()
     )
 }
 
@@ -384,3 +385,6 @@ class HunterFansub : Madara("Hunter Fansub", "https://hunterfansub.com", "es") {
 class MangaArabTeam : Madara("مانجا عرب تيم Manga Arab Team", "https://mangaarabteam.com", "ar")
 
 class NightComic : Madara("Night Comic", "http://www.nightcomic.com", "en")
+
+class Toonily : Madara("Toonily", "https://toonily.com", "en")
+


### PR DESCRIPTION
The standalone toonily extension was presenting problems and was being reported in Discord. 
The site appears to be running Madara so I added it for now.

Tested it and it seems to be loading everything as expected.

Todo by anyone:
Clean up standalone extension after merge (and confirmation it works)