### PR TITLE
Mangakakalot description parsing

### DIFF
--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBox.kt
@@ -126,7 +126,7 @@ abstract class MangaBox (
                     infoElement.select("td:containsOwn(genres) + td a").joinToString { it.text() }
                 }
             }
-            description = document.select(descriptionSelector)?.first()?.ownText()
+            description = document.select(descriptionSelector)?.first()?.ownText()?.replace("\\<br\\>", "\n")?.replace("\\<.*?\\>", "")?.replace("^$title summary\\:", "")
             thumbnail_url = document.select(thumbnailSelector).attr("abs:src")
         }
     }


### PR DESCRIPTION
In manga description:
replace __\<br\>__ tags with __'\n'__ (line break)
remove any other tags (such as __\<b\>__ or __\</b\>__ for example)
some descriptions start with __"[_manga title_] summary:"__, remove it as it adds nothing to the context