### PR TITLE
MangaBox - Kakalot search

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 

--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBoxFactory.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBoxFactory.kt
@@ -30,14 +30,16 @@ class MangaBoxFactory : SourceFactory {
 
 //TODO: Alternate search/filters for some sources that don't use query parameters
 
-class Mangakakalot : MangaBox("Mangakakalot", "http://mangakakalot.com", "en")
+class Mangakakalot : MangaBox("Mangakakalot", "http://mangakakalot.com", "en") {
+    override fun searchMangaSelector() = "${super.searchMangaSelector()}, div.list-truyen-item-wrap"
+}
 
 class Manganelo : MangaBox("Manganelo", "https://manganelo.com", "en") {
     // Nelo's date format is part of the base class
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/genre-all/$page?type=topview", headers)
     override fun popularMangaSelector() = "div.content-genres-item"
     override val latestUrlPath = "genre-all/"
-    override fun searchMangaSelector() = "div.search-story-item"
+    override fun searchMangaSelector() = "div.search-story-item, div.content-genres-item"
     override fun getFilterList() = FilterList()
 }
 


### PR DESCRIPTION
Fixes Kakalot's filtered search (https://github.com/inorichi/tachiyomi-extensions/issues/1895), don't want to deal with Nelo right now.

Should be able to merge this along with https://github.com/inorichi/tachiyomi-extensions/pull/1893, right?