### PR TITLE
Madara - add Wakamics, remove Tritinia

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 40
+    extVersionCode = 41
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -29,7 +29,6 @@ class MadaraFactory : SourceFactory {
         AoCTranslations(),
         KomikGo(),
         LuxyScans(),
-        TritiniaScans(),
         TsubakiNoScan(),
         YokaiJump(),
         ZManga(),
@@ -64,7 +63,8 @@ class MadaraFactory : SourceFactory {
         NightComic(),
         Toonily(),
         PlotTwistScan(),
-        MangaKomi()
+        MangaKomi(),
+        Wakamics()
     )
 }
 
@@ -118,14 +118,6 @@ class AoCTranslations : Madara("Agent of Change Translations", "https://aoc.moe"
 class KomikGo : Madara("KomikGo", "https://komikgo.com", "id")
 
 class LuxyScans : Madara("Luxy Scans", "https://luxyscans.com/", "en")
-
-class TritiniaScans : Madara("Tritinia Scans", "http://ghajik.ml/", "en",
-    dateFormat = SimpleDateFormat("dd/MM/yy", Locale.US)) {
-    override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/?m_orderby=views", headers)
-    override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/?m_orderby=latest", headers)
-    override fun latestUpdatesNextPageSelector(): String? = null
-    override fun popularMangaNextPageSelector(): String? = null
-}
 
 class TsubakiNoScan : Madara("Tsubaki No Scan", "https://tsubakinoscan.com/","fr",
     dateFormat = SimpleDateFormat("dd/MM/yy", Locale.US))
@@ -403,4 +395,6 @@ class PlotTwistScan : Madara("Plot Twist No Fansub", "https://www.plotwistscan.c
 }
 
 class MangaKomi : Madara("MangaKomi", "https://mangakomi.com", "en")
+
+class Wakamics : Madara("Wakamics", "https://wakamics.com", "en")
 


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/1966 and https://github.com/inorichi/tachiyomi-extensions/issues/1967

Didn't remove ToonManga in case they stop forwarding/return to themselves in the near future; will remove if they don't.  Added the site they're forwarding to (wakamics) as its own source.

Removed Tritinia Scans--my understanding is that they will publish to MangaDex instead of their own site from now on.