### PR TITLE
Mangabat pagelist Empty

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 

--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBoxFactory.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBoxFactory.kt
@@ -71,7 +71,7 @@ class Mangabat : MangaBox("Mangabat", "https://mangabat.com", "en") {
     override val mangaDetailsMainSelector = "div.truyen_info"
     override val thumbnailSelector = "img.info_image_manga"
     override val descriptionSelector = "div#contentm"
-    override val pageListSelector = "div.vung_doc img"
+    override val pageListSelector = "div.vung_doc img, ${super.pageListSelector}" //some chapters link to Nelo
 }
 
 class KonoBasho : MangaBox("Kono-Basho", "https://kono-basho.com", "en", SimpleDateFormat("MMM dd,yy", Locale.ENGLISH)) {
@@ -87,7 +87,7 @@ class MangaOnl : MangaBox("MangaOnl", "https://mangaonl.com", "en") {
     override val popularUrlPath = "story-list-ty-topview-st-all-ca-all-"
     override val latestUrlPath = "story-list-ty-latest-st-all-ca-all-"
     override fun popularMangaSelector() = "div.story_item"
-    override val mangaDetailsMainSelector = "div.panel_story_info, ${super.mangaDetailsMainSelector}"
+    override val mangaDetailsMainSelector = "div.panel_story_info, ${super.mangaDetailsMainSelector}" //Some manga link to Nelo
     override val thumbnailSelector = "img.story_avatar, ${super.thumbnailSelector}"
     override val descriptionSelector = "div.panel_story_info_description, ${super.descriptionSelector}"
     override fun chapterListSelector() = "div.chapter_list_title + ul li, ${super.chapterListSelector()}"


### PR DESCRIPTION
Reported via discord 
Fixes #2000

The only examples I could find are Mangabat hosting the manga details page themselves but link to Nelo for the chapter / reader. I don't think there is a need to change anything else. 

Also added a quick comment to help explain what is going on. 