### PR TITLE
[Toomics] Filter out 'free in app' chapters

### DIFF
--- a/src/all/toomics/build.gradle
+++ b/src/all/toomics/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Toomics'
     pkgNameSuffix = 'all.toomics'
     extClass = '.ToomicsFactory'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
+++ b/src/all/toomics/src/eu/kanade/tachiyomi/extension/all/toomics/ToomicsGlobal.kt
@@ -98,7 +98,7 @@ abstract class ToomicsGlobal(private val siteLang: String,
             .map { it.reversed() }
     }
 
-    override fun chapterListSelector(): String = "section.ep-body ol.list-ep li.normal_ep a:not([onclick*='login'])"
+    override fun chapterListSelector(): String = "section.ep-body ol.list-ep li.normal_ep a:not([onclick*='login']):not([onclick*='free_in_app'])"
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         val num = element.select("div.cell-num span.num").text()


### PR DESCRIPTION
These end up having 'empty pagelist' errors as well
Ultimately the ext should figure out how to use the same requests that the Toomics native app uses, but that's for a later time