### PR TITLE
MangaOwl - chapter URLs

### DIFF
--- a/src/en/mangaowl/build.gradle
+++ b/src/en/mangaowl/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaOwl'
     pkgNameSuffix = 'en.mangaowl'
     extClass = '.MangaOwl'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangaowl/src/eu/kanade/tachiyomi/extension/en/mangaowl/MangaOwl.kt
+++ b/src/en/mangaowl/src/eu/kanade/tachiyomi/extension/en/mangaowl/MangaOwl.kt
@@ -8,7 +8,7 @@ import okhttp3.Request
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 
 class MangaOwl : ParsedHttpSource() {
 
@@ -98,7 +98,8 @@ class MangaOwl : ParsedHttpSource() {
     override fun chapterFromElement(element: Element): SChapter {
         val chapter = SChapter.create()
         element.select("a").let {
-            chapter.setUrlWithoutDomain(it.attr("href"))
+            // They replace some URLs with a different host getting a path of domain.com/reader/reader/, fix to make usable on baseUrl
+            chapter.setUrlWithoutDomain(it.attr("href").replace("/reader/reader/", "/reader/"))
             chapter.name = it.text()
         }
         chapter.date_upload = parseChapterDate(element.select("td + td").text())
@@ -119,12 +120,9 @@ class MangaOwl : ParsedHttpSource() {
     // Pages
 
     override fun pageListParse(document: Document): List<Page> {
-        val pages = mutableListOf<Page>()
-
-        document.select("div.item img.owl-lazy").forEachIndexed { i, img ->
-            pages.add(Page(i, "", img.attr("abs:data-src")))
+        return document.select("div.item img.owl-lazy").mapIndexed { i, img ->
+            Page(i, "", img.attr("abs:data-src"))
         }
-        return pages
     }
 
     override fun imageUrlParse(document: Document): String = throw UnsupportedOperationException("Not used")

--- a/src/en/mangaowl/src/eu/kanade/tachiyomi/extension/en/mangaowl/MangaOwl.kt
+++ b/src/en/mangaowl/src/eu/kanade/tachiyomi/extension/en/mangaowl/MangaOwl.kt
@@ -9,6 +9,7 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 class MangaOwl : ParsedHttpSource() {
 
@@ -20,7 +21,11 @@ class MangaOwl : ParsedHttpSource() {
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.cloudflareClient
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .connectTimeout(1, TimeUnit.MINUTES)
+        .readTimeout(1, TimeUnit.MINUTES)
+        .writeTimeout(1, TimeUnit.MINUTES)
+        .build()
 
     // Popular
 


### PR DESCRIPTION
Directed at fixing some chapter URLs causing an error 500.  Users experiencing that error should be directed to update and refresh any chapter list that generate that error.

Also, can close https://github.com/inorichi/tachiyomi-extensions/issues/1679.