### PR TITLE
NineMangaEn - Account for subdomain

### DIFF
--- a/src/all/ninemanga/build.gradle
+++ b/src/all/ninemanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: NineManga'
     pkgNameSuffix = "all.ninemanga"
     extClass = '.NineMangaFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -4,8 +4,8 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import okhttp3.Request
+import org.jsoup.nodes.Element
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Calendar

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -22,7 +22,15 @@ class NineMangaFactory : SourceFactory {
     )
 }
 
-class NineMangaEn : NineManga("NineMangaEn", "http://en.ninemanga.com", "en")
+class NineMangaEn : NineManga("NineMangaEn", "http://en.ninemanga.com", "en"){
+    override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
+        element.select("a.bookname").let {
+            url = it.attr("abs:href").replace("www","en").substringAfter(baseUrl)
+            title = it.text()
+        }
+        thumbnail_url = element.select("img").attr("abs:src")
+    }
+}
 
 class NineMangaEs : NineManga("NineMangaEs", "http://es.ninemanga.com", "es") {
     // ES, FR, RU don't return results for searches with an apostrophe

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -22,7 +22,7 @@ class NineMangaFactory : SourceFactory {
     )
 }
 
-class NineMangaEn : NineManga("NineMangaEn", "http://en.ninemanga.com", "en"){
+class NineMangaEn : NineManga("NineMangaEn", "http://en.ninemanga.com", "en") {
     override fun latestUpdatesFromElement(element: Element) = SManga.create().apply {
         element.select("a.bookname").let {
             url = it.attr("abs:href").replace("www","en").substringAfter(baseUrl)

--- a/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
+++ b/src/all/ninemanga/src/eu/kanade/tachiyomi/extension/all/ninemanga/NineMangaFactory.kt
@@ -4,6 +4,7 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import okhttp3.Request
 import java.text.ParseException
 import java.text.SimpleDateFormat


### PR DESCRIPTION
Fixes #2017
Ninemanga doesn't know which subdomain to give for en users. 

- Latest it uses www
- Popular it uses en

Now accounts and changes www.ninemanga.com to en.ninemanga.com

I don't know why it doesn't use setUrlWithoutDomain() but I didn't want to change too much.
