### PR TITLE
Mangadex: Use preferences to specify domain

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 78
+    extVersionCode = 79
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -37,8 +37,9 @@ abstract class Mangadex(
     override val name = "MangaDex"
 
     override val baseUrl = "https://mangadex.org"
+    get() = getDomain()
 
-    private val cdnUrl = "https://mangadex.org" // "https://s0.mangadex.org"
+    private val cdnUrl = "https://s0.mangadex.org"
 
     override val supportsLatest = true
 
@@ -672,10 +673,25 @@ abstract class Mangadex(
                 preferences.edit().putString(SERVER_PREF, entry).commit()
             }
         }
+        val domainPref = ListPreference(screen.context).apply {
+            key = DOMAIN_PREF
+            title = DOMAIN_PREF_Title
+            entries = DOMAIN_PREF_ENTRIES
+            entryValues = DOMAIN_PREF_ENTRIES
+            summary = "%s"
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val selected = newValue as String
+                val index = this.findIndexOfValue(selected)
+                val entry = entryValues[index] as String
+                preferences.edit().putString(DOMAIN_PREF, entry).commit()
+            }
+        }
 
         screen.addPreference(myPref)
         screen.addPreference(thumbsPref)
         screen.addPreference(serverPref)
+        screen.addPreference(domainPref)
     }
 
     private fun getShowR18(): Int = preferences.getInt(SHOW_R18_PREF, 0)
@@ -683,6 +699,11 @@ abstract class Mangadex(
     private fun getServer(): String {
         val default = SERVER_PREF_ENTRY_VALUES.first()
         return preferences.getString(SERVER_PREF, default).takeIf { it in SERVER_PREF_ENTRY_VALUES }
+            ?: default
+    }
+    private fun getDomain(): String {
+        val default = DOMAIN_PREF_ENTRIES.first()
+        preferences.getString(DOMAIN_PREF, default).takeIf { it in DOMAIN_PREF_ENTRIES }
             ?: default
     }
 
@@ -852,6 +873,10 @@ abstract class Mangadex(
         private const val SERVER_PREF = "imageServer"
         private val SERVER_PREF_ENTRIES = arrayOf("Automatic", "NA/EU 1", "NA/EU 2", "Rest of the world")
         private val SERVER_PREF_ENTRY_VALUES = arrayOf("0", "na", "na2", "row")
+
+        private const val DOMAIN_PREF_Title = "Domain preference"
+        private const val DOMAIN_PREF = "domainServer"
+        private val DOMAIN_PREF_ENTRIES = arrayOf("mangadex.org", "mangadex.cc")
 
         private const val API_MANGA = "/api/manga/"
         private const val API_CHAPTER = "/api/chapter/"

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -36,11 +36,9 @@ abstract class Mangadex(
 
     override val name = "MangaDex"
 
-    override val baseUrl
-    get() = getDomain()
+    override val baseUrl get() = getDomain()
 
-    private val cdnUrl
-    get() = getDomain()
+    private val cdnUrl get() = getDomain()
 
     override val supportsLatest = true
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -39,7 +39,7 @@ abstract class Mangadex(
     override val baseUrl = "https://mangadex.org"
     get() = getDomain()
 
-    private val cdnUrl = "https://s0.mangadex.org"
+    private val cdnUrl = baseUrl
 
     override val supportsLatest = true
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -38,9 +38,11 @@ abstract class Mangadex(
 
     override val baseUrl = "https://mangadex.org"
     get() = getDomain()
+    set(value) { field = value }
 
     private val cdnUrl = "https://mangadex.org"
     get() = getDomain()
+    set(value) { field = value }
 
     override val supportsLatest = true
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -702,8 +702,7 @@ abstract class Mangadex(
             ?: default
     }
     private fun getDomain(): String {
-        val default = DOMAIN_PREF_ENTRIES.first()
-        preferences.getString(DOMAIN_PREF, default).takeIf { it in DOMAIN_PREF_ENTRIES }
+        preferences.getString(DOMAIN_PREF, DOMAIN_PREF_DEFAULT).takeIf { it in DOMAIN_PREF_ENTRIES }
             ?: default
     }
 
@@ -877,6 +876,7 @@ abstract class Mangadex(
         private const val DOMAIN_PREF_Title = "Domain preference"
         private const val DOMAIN_PREF = "domainServer"
         private val DOMAIN_PREF_ENTRIES = arrayOf("mangadex.org", "mangadex.cc")
+        private val DOMAIN_PREF_DEFAULT = "mangadex.org"
 
         private const val API_MANGA = "/api/manga/"
         private const val API_CHAPTER = "/api/chapter/"

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -36,13 +36,11 @@ abstract class Mangadex(
 
     override val name = "MangaDex"
 
-    override val baseUrl = "https://mangadex.org"
+    override val baseUrl
     get() = getDomain()
-    set(value) { field = value }
 
-    private val cdnUrl = "https://mangadex.org"
+    private val cdnUrl
     get() = getDomain()
-    set(value) { field = value }
 
     override val supportsLatest = true
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -39,7 +39,8 @@ abstract class Mangadex(
     override val baseUrl = "https://mangadex.org"
     get() = getDomain()
 
-    private val cdnUrl = baseUrl
+    private val cdnUrl = "https://mangadex.org"
+    get() = getDomain()
 
     override val supportsLatest = true
 
@@ -702,8 +703,8 @@ abstract class Mangadex(
             ?: default
     }
     private fun getDomain(): String {
-        preferences.getString(DOMAIN_PREF, DOMAIN_PREF_DEFAULT).takeIf { it in DOMAIN_PREF_ENTRIES }
-            ?: default
+        return preferences.getString(DOMAIN_PREF, DOMAIN_PREF_DEFAULT).takeIf { it in DOMAIN_PREF_ENTRIES }
+            ?: DOMAIN_PREF_DEFAULT
     }
 
     private class TextField(name: String, val key: String) : Filter.Text(name)


### PR DESCRIPTION
This is future proofing so that if org goes down once more, or if more domains are added, it can be changed (default) or set specifically through the defaults in updates.

- [x] Built
- [x] Tested
- [ ] Ready to merge