### PR TITLE
Fix Rawkuma date parsing

### DIFF
--- a/src/ja/rawkuma/build.gradle
+++ b/src/ja/rawkuma/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Rawkuma'
     pkgNameSuffix = 'ja.rawkuma'
     extClass = '.Rawkuma'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
+++ b/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
@@ -157,13 +157,13 @@ class Rawkuma: ParsedHttpSource() {
         document.select(chapterListSelector()).map { chapters.add(chapterFromElement(it)) }
         // Add date for latest chapter only
         document.select("time[itemprop=dateModified]").attr("datetime")
-            .let { chapters[0].date_upload = parseDate(it) }
+            .let { chapters[0].date_upload = parseDate(it.substringBefore("+")) }
         return chapters
     }
 
     private fun parseDate(date: String): Long {
         return try {
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US).parse(date).time
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).parse(date).time
         } catch (e: ParseException) {
             0L
         }

--- a/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
+++ b/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
@@ -11,6 +11,7 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
+import java.util.Locale
 
 class Rawkuma: ParsedHttpSource() {
 
@@ -160,7 +161,11 @@ class Rawkuma: ParsedHttpSource() {
     }
 
     private fun parseDate(date: String): Long {
-        return SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX").parse(date).time
+        return try {
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX" Locale.US).parse(date).time
+        } catch (e: ParseException) {
+            0L
+        }
     }
 
     override fun chapterListSelector() = ".lchx"

--- a/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
+++ b/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
@@ -157,15 +157,19 @@ class Rawkuma: ParsedHttpSource() {
         document.select(chapterListSelector()).map { chapters.add(chapterFromElement(it)) }
         // Add date for latest chapter only
         document.select("time[itemprop=dateModified]").attr("datetime")
-            .let { chapters[0].date_upload = parseDate(it.substringBefore("+")) }
+            .let { chapters[0].date_upload = parseDate(it) }
         return chapters
     }
 
     private fun parseDate(date: String): Long {
         return try {
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).parse(date).time
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US).parse(date).time
         } catch (e: ParseException) {
-            0L
+            try {
+                SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US).parse(date.substringBefore("+")).time
+            } catch (e: ParseException) {
+                0L
+            }
         }
     }
 

--- a/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
+++ b/src/ja/rawkuma/src/eu/kanade/tachiyomi/extension/ja/rawkuma/Rawkuma.kt
@@ -10,6 +10,7 @@ import okhttp3.Request
 import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -162,7 +163,7 @@ class Rawkuma: ParsedHttpSource() {
 
     private fun parseDate(date: String): Long {
         return try {
-            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX" Locale.US).parse(date).time
+            SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX", Locale.US).parse(date).time
         } catch (e: ParseException) {
             0L
         }


### PR DESCRIPTION
Fixes #2061 

Pattern X is only part of API 24+ (Android 7)
X | Time zone | ISO 8601 time zone | -08; -0800; -08:00 | 24+

I removed the time zone because we are really looking for the date only. 
I added a try and catch just in case something changes.

Tested OK to ensure I didn't break anything. 
