### PR TITLE
Mangahere Update Page List for Webtoons

### DIFF
--- a/src/en/mangahere/build.gradle
+++ b/src/en/mangahere/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangahere'
     pkgNameSuffix = 'en.mangahere'
     extClass = '.Mangahere'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -19,7 +19,7 @@ class Mangahere : ParsedHttpSource() {
 
     override val name = "Mangahere"
 
-    override val baseUrl = "http://www.mangahere.cc"
+    override val baseUrl = "https://www.mangahere.cc"
 
     override val lang = "en"
 
@@ -193,15 +193,15 @@ class Mangahere : ParsedHttpSource() {
 
     override fun pageListParse(document: Document): List<Page> {
         val bar = document.select("script[src*=chapter_bar]")
-        if (!bar.isNullOrEmpty()){
+        if (!bar.isNullOrEmpty()){ //Webtoonviewer or cascade, all images on one page
             val script = document.select("script:containsData(function(p,a,c,k,e,d))").html().removePrefix("eval")
             val duktape = Duktape.create()
             val DeobfuscatedScript = duktape.evaluate(script).toString()
             val urls = DeobfuscatedScript.substringAfter("newImgs=['").substringBefore("'];").split("','")
             duktape.close()
             val pages = mutableListOf<Page>()
-            urls.forEachIndexed { index, s ->
-                pages.add(Page(index, "", "http:$s"))
+            for (i in 0 until urls.size-1) { 
+                pages.add(Page(i,"","https:${urls[i]}"))
             }
             return pages
         } else {

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -191,109 +191,19 @@ class Mangahere : ParsedHttpSource() {
 			}
     }
 
-    override fun pageListParse(document: Document): List<Page> {
-        val bar = document.select("script[src*=chapter_bar]")
-        if (!bar.isNullOrEmpty()){ //Webtoonviewer or cascade, all images on one page
-            val script = document.select("script:containsData(function(p,a,c,k,e,d))").html().removePrefix("eval")
-            val duktape = Duktape.create()
-            val DeobfuscatedScript = duktape.evaluate(script).toString()
-            val urls = DeobfuscatedScript.substringAfter("newImgs=['").substringBefore("'];").split("','")
-            duktape.close()
-            val pages = mutableListOf<Page>()
-            for (i in 0 until urls.size-1) { 
-                pages.add(Page(i,"","https:${urls[i]}"))
-            }
-            return pages
-        } else {
+    override fun pageListRequest(chapter: SChapter): Request {
+        return GET("$baseUrl/${chapter.url}".replace("www","m"))
+    }
 
-        val html = document.html()
-        val link = document.location()
-
-        val pages = mutableListOf<Page>()
-
-        val duktape = Duktape.create()
-
-        var secretKey = extractSecretKey(html, duktape)
-
-        val chapterIdStartLoc =  html.indexOf("chapterid")
-        val chapterId = html.substring(
-                chapterIdStartLoc + 11,
-                html.indexOf(";", chapterIdStartLoc)).trim()
-
-        val chapterPagesElement = document.select(".pager-list-left > span").first()
-        val pagesLinksElements = chapterPagesElement.select("a")
-        val pagesNumber = pagesLinksElements.get(pagesLinksElements.size - 2).attr("data-page").toInt()
-
-        val pageBase = link.substring(0, link.lastIndexOf("/"))
-
-        for (i in 1..pagesNumber){
-
-            val pageLink = "${pageBase}/chapterfun.ashx?cid=$chapterId&page=$i&key=$secretKey"
-
-            var responseText = ""
-
-            for (tr in 1..3){
-
-                val request = Request.Builder()
-                        .url(pageLink)
-                        .addHeader("Referer",link)
-                        .addHeader("Accept","*/*")
-                        .addHeader("Accept-Language","en-US,en;q=0.9")
-                        .addHeader("Connection","keep-alive")
-                        .addHeader("Host","www.mangahere.cc")
-                        .addHeader("User-Agent", System.getProperty("http.agent") ?: "")
-                        .addHeader("X-Requested-With","XMLHttpRequest")
-                        .build()
-
-                val response = client.newCall(request).execute()
-                responseText = response.body()!!.string()
-
-                if (responseText.isNotEmpty())
-                    break
-                else
-                    secretKey = ""
-
-            }
-
-            val deobfuscatedScript = duktape.evaluate(responseText.removePrefix("eval")).toString()
-
-            val baseLinkStartPos = deobfuscatedScript.indexOf("pix=") + 5
-            val baseLinkEndPos = deobfuscatedScript.indexOf(";", baseLinkStartPos) - 1
-            val baseLink = deobfuscatedScript.substring(baseLinkStartPos, baseLinkEndPos)
-
-            val imageLinkStartPos = deobfuscatedScript.indexOf("pvalue=") + 9
-            val imageLinkEndPos = deobfuscatedScript.indexOf("\"", imageLinkStartPos)
-            val imageLink = deobfuscatedScript.substring(imageLinkStartPos, imageLinkEndPos)
-
-            pages.add(Page(i, "", "http:$baseLink$imageLink"))
-
-        }
-
-        duktape.close()
-
-        return pages
+    override fun pageListParse(document: Document): List<Page> =  mutableListOf<Page>().apply {
+        document.select("select option").forEach {
+            add(Page(size,"https:${it.attr("value")}"))
         }
     }
 
-    private fun extractSecretKey(html: String, duktape: Duktape): String {
-
-        val secretKeyScriptLocation = html.indexOf("eval(function(p,a,c,k,e,d)")
-        val secretKeyScriptEndLocation = html.indexOf("</script>", secretKeyScriptLocation)
-        val secretKeyScript = html.substring(secretKeyScriptLocation, secretKeyScriptEndLocation).removePrefix("eval")
-
-        val secretKeyDeobfuscatedScript = duktape.evaluate(secretKeyScript).toString()
-
-        val secretKeyStartLoc = secretKeyDeobfuscatedScript.indexOf("'")
-        val secretKeyEndLoc = secretKeyDeobfuscatedScript.indexOf(";")
-
-        val secretKeyResultScript = secretKeyDeobfuscatedScript.substring(
-                secretKeyStartLoc, secretKeyEndLoc)
-
-        return duktape.evaluate(secretKeyResultScript).toString()
-
+    override fun imageUrlParse(document: Document): String {
+        return document.select("img#image").attr("src")
     }
-
-    override fun imageUrlParse(document: Document) = document.getElementById("image").attr("src")
 
     private class Genre(title: String, val id: Int) : Filter.TriState(title)
 

--- a/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
+++ b/src/en/mangahere/src/eu/kanade/tachiyomi/extension/en/mangahere/Mangahere.kt
@@ -192,7 +192,7 @@ class Mangahere : ParsedHttpSource() {
     }
 
     override fun pageListRequest(chapter: SChapter): Request {
-        return GET("$baseUrl/${chapter.url}".replace("www","m"))
+        return GET("$baseUrl/${chapter.url}".replace("www","m"), headers)
     }
 
     override fun pageListParse(document: Document): List<Page> =  mutableListOf<Page>().apply {


### PR DESCRIPTION
Fixes #2107 

Mangahere normally has a insert image for the mangazone app as the last page. However, it doesn't get inserted properly for the webtoon viewer type. 

The invalid last image is now bypassed by reducing the total images by 1. It should not affect actual pages that are important. 

Also, changed to https