### PR TITLE
fix chapter list not reflecting blocked groups from mangadex

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 78
+    extVersionCode = 79
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -347,13 +347,19 @@ abstract class Mangadex(
     }
 
     private fun apiRequest(manga: SManga): Request {
-        return GET(baseUrl + API_MANGA + getMangaId(manga.url), headers)
+        return GETNoCache(baseUrl + API_MANGA + getMangaId(manga.url), headers)
     }
 
     private fun searchMangaByIdRequest(id: String): Request {
-        return GET(baseUrl + API_MANGA + id, headers)
+        return GETNoCache(baseUrl + API_MANGA + id, headers)
     }
-
+    private fun GETNoCache(url: String, headers: Headers): Request {
+        return Request.Builder()
+            .url(url)
+            .headers(Headers.Builder().build())
+            .cacheControl(CacheControl.FORCE_NETWORK)
+            .build()
+    }
     private fun getMangaId(url: String): String {
         val lastSection = url.trimEnd('/').substringAfterLast("/")
         return if (lastSection.toIntOrNull() != null) {

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -347,19 +347,13 @@ abstract class Mangadex(
     }
 
     private fun apiRequest(manga: SManga): Request {
-        return GETNoCache(baseUrl + API_MANGA + getMangaId(manga.url), headers)
+        return GET(baseUrl + API_MANGA + getMangaId(manga.url), headers, CacheControl.FORCE_NETWORK)
     }
 
     private fun searchMangaByIdRequest(id: String): Request {
-        return GETNoCache(baseUrl + API_MANGA + id, headers)
+        return GET(baseUrl + API_MANGA + id, headers, CacheControl.FORCE_NETWORK)
     }
-    private fun GETNoCache(url: String, headers: Headers): Request {
-        return Request.Builder()
-            .url(url)
-            .headers(Headers.Builder().build())
-            .cacheControl(CacheControl.FORCE_NETWORK)
-            .build()
-    }
+
     private fun getMangaId(url: String): String {
         val lastSection = url.trimEnd('/').substringAfterLast("/")
         return if (lastSection.toIntOrNull() != null) {


### PR DESCRIPTION
Force network instead of using cache when getting manga info and chapter list for mangadex.
