### PR TITLE
Madara APC Fix

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 46
+    extVersionCode = 47
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -5,7 +5,6 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.Filter
@@ -215,7 +214,7 @@ class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
     private val userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("User-Agent", userAgent)
-        .add("Referer", "$baseUrl/manga/?m_orderby=views"))
+        .add("Referer", "$baseUrl/manga/?m_orderby=views")
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=views", headers)
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=latest", headers)
     override fun searchMangaNextPageSelector() = "a[rel=next]"

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -215,8 +215,11 @@ class AdonisFansub : Madara("Adonis Fansub", "https://manga.adonisfansub.com", "
 class GetManhwa : Madara("GetManhwa", "https://getmanhwa.co", "en")
 
 class AllPornComic : Madara("AllPornComic", "https://allporncomic.com", "en") {
+    override val client: OkHttpClient = network.client
+    private val userAgent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/79.0.3945.117 Safari/537.36"
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.${Random().nextInt(99)} (KHTML, like Gecko) Chrome/79.0.${Random().nextInt(9999)}.${Random().nextInt(999)} Safari/537.${Random().nextInt(99)}")
+        .add("User-Agent", userAgent)
+        .add("Referer", "$baseUrl/manga/?m_orderby=views"))
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=views", headers)
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=latest", headers)
     override fun searchMangaNextPageSelector() = "a[rel=next]"

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -5,19 +5,15 @@ import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.HttpUrl
-import okhttp3.Headers
-import okhttp3.OkHttpClient
+import okhttp3.*
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
-import java.util.Locale
-import java.util.Random
+import java.util.*
 
 class MadaraFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(


### PR DESCRIPTION
I didn't want to do this but people #2113 kept #2069 complaining #2029 !

This I feel will be my final "fix". 

Wordfence is a bit difficult to defeat partially because I don't know what they are doing that keeps triggering 503 forbidden and the help documentation only explains so much. (Though I guess I can install it myself to take a closer look)

- Uses latest Chrome user agent. De-randomized, because that isn't working anymore anyways. I keep thinking I dare them to block the standard chrome user agent but I know that isn't what will happen either way. 
- Adds refer back just in case
- Changes the cloudflare client to the normal client to stop throwing the cloudflare error.