### PR TITLE
Fix a wrong word on HQNow extension

### DIFF
--- a/src/pt/hqnow/build.gradle
+++ b/src/pt/hqnow/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: HQ Now!'
     pkgNameSuffix = 'pt.hqnow'
     extClass = '.HQNow'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/pt/hqnow/src/eu/kanade/tachiyomi/extension/pt/hqnow/HQNow.kt
+++ b/src/pt/hqnow/src/eu/kanade/tachiyomi/extension/pt/hqnow/HQNow.kt
@@ -150,7 +150,7 @@ class HQNow : HttpSource() {
         LetterFilter()
     )
 
-    private class LetterFilter : UriPartFilter("Carta", arrayOf(
+    private class LetterFilter : UriPartFilter("Letra", arrayOf(
         Pair("---","<Selecione>"),
         Pair("a","A"),
         Pair("b","B"),


### PR DESCRIPTION
The title of the letter filter is bad translated from English to Portuguese.

The current word, *carta*, means "a paper letter", and not "a letter from the alphabet", that would be *letra*.

This PR changes the word to the correct one.