### PR TITLE
Remove deprecated Optional annotations on MangaPlus

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -6,7 +6,7 @@ ext {
     appName = 'Tachiyomi: MANGA Plus by SHUEISHA'
     pkgNameSuffix = 'all.mangaplus'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -269,9 +269,10 @@ abstract class MangaPlus(override val lang: String,
         if (Build.VERSION.SDK_INT > Build.VERSION_CODES.KITKAT)
             return ProtoBuf.load(MangaPlusSerializer, body()!!.bytes())
 
-        // Apparently, the version used of Kotlinx Serialization lib causes a crash
-        // on KitKat devices (see #1678). So, if the device is running KitKat or lower,
-        // we use the old method of parsing their API -- using ProtobufJS + Duktape + Gson.
+        // Apparently, the Kotlinx Serialization lib causes a crash on KitKat devices (see #1678).
+        // So, if the device is running KitKat or lower, we use the old method of parsing
+        // their API -- using ProtobufJS + Duktape + Gson. When the repository drops the
+        // support for KitKat devices, the old way can be removed.
 
         val bytes = body()!!.bytes()
         val messageBytes = "var BYTE_ARR = new Uint8Array([${bytes.joinToString()}]);"

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
@@ -1,7 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.mangaplus
 
 import com.google.gson.annotations.SerializedName
-import kotlinx.serialization.Optional
 import kotlinx.serialization.SerialId
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
@@ -11,8 +10,8 @@ object MangaPlusSerializer
 
 @Serializable
 data class MangaPlusResponse(
-    @Optional @SerialId(1) val success: SuccessResult? = null,
-    @Optional @SerialId(2) val error: ErrorResult? = null
+    @SerialId(1) val success: SuccessResult? = null,
+    @SerialId(2) val error: ErrorResult? = null
 )
 
 @Serializable
@@ -32,12 +31,12 @@ data class Popup(
 
 @Serializable
 data class SuccessResult(
-    @Optional @SerialId(1) val isFeaturedUpdated: Boolean? = false,
-    @Optional @SerialId(5) val allTitlesView: AllTitlesView? = null,
-    @Optional @SerialId(6) val titleRankingView: TitleRankingView? = null,
-    @Optional @SerialId(8) val titleDetailView: TitleDetailView? = null,
-    @Optional @SerialId(10) val mangaViewer: MangaViewer? = null,
-    @Optional @SerialId(11) val webHomeView: WebHomeView? = null
+    @SerialId(1) val isFeaturedUpdated: Boolean? = false,
+    @SerialId(5) val allTitlesView: AllTitlesView? = null,
+    @SerialId(6) val titleRankingView: TitleRankingView? = null,
+    @SerialId(8) val titleDetailView: TitleDetailView? = null,
+    @SerialId(10) val mangaViewer: MangaViewer? = null,
+    @SerialId(11) val webHomeView: WebHomeView? = null
 )
 
 @Serializable
@@ -55,13 +54,13 @@ data class TitleDetailView(
     @SerialId(2) val titleImageUrl: String,
     @SerialId(3) val overview: String,
     @SerialId(4) val backgroundImageUrl: String,
-    @Optional @SerialId(5) val nextTimeStamp: Int = 0,
-    @Optional @SerialId(6) val updateTiming: UpdateTiming? = UpdateTiming.DAY,
-    @Optional @SerialId(7) val viewingPeriodDescription: String = "",
+    @SerialId(5) val nextTimeStamp: Int = 0,
+    @SerialId(6) val updateTiming: UpdateTiming? = UpdateTiming.DAY,
+    @SerialId(7) val viewingPeriodDescription: String = "",
     @SerialId(9) val firstChapterList: List<Chapter> = emptyList(),
-    @Optional @SerialId(10) val lastChapterList: List<Chapter> = emptyList(),
-    @Optional @SerialId(14) val isSimulReleased: Boolean = true,
-    @Optional @SerialId(17) val chaptersDescending: Boolean = true
+    @SerialId(10) val lastChapterList: List<Chapter> = emptyList(),
+    @SerialId(14) val isSimulReleased: Boolean = true,
+    @SerialId(17) val chaptersDescending: Boolean = true
 )
 
 enum class UpdateTiming { NOT_REGULARLY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY, DAY }
@@ -77,9 +76,10 @@ data class Title(
     @SerialId(4) val portraitImageUrl: String,
     @SerialId(5) val landscapeImageUrl: String,
     @SerialId(6) val viewCount: Int,
-    @Optional @SerialId(7) val language: Language? = Language.ENGLISH
+    @SerialId(7) val language: Language? = Language.ENGLISH
 )
 
+@Serializable
 enum class Language(val id: Int) {
     @SerialId(0)
     @SerializedName("0")
@@ -98,7 +98,7 @@ data class UpdatedTitleGroup(
 
 @Serializable
 data class UpdatedTitle(
-    @Optional @SerialId(1) val title: Title? = null
+    @SerialId(1) val title: Title? = null
 )
 
 @Serializable
@@ -106,20 +106,20 @@ data class Chapter(
     @SerialId(1) val titleId: Int,
     @SerialId(2) val chapterId: Int,
     @SerialId(3) val name: String,
-    @Optional @SerialId(4) val subTitle: String? = null,
+    @SerialId(4) val subTitle: String? = null,
     @SerialId(6) val startTimeStamp: Int,
     @SerialId(7) val endTimeStamp: Int
 )
 
 @Serializable
-data class MangaPlusPage(@Optional @SerialId(1) val page: MangaPage? = null)
+data class MangaPlusPage(@SerialId(1) val page: MangaPage? = null)
 
 @Serializable
 data class MangaPage(
     @SerialId(1) val imageUrl: String,
     @SerialId(2) val width: Int,
     @SerialId(3) val height: Int,
-    @Optional @SerialId(5) val encryptionKey: String? = null
+    @SerialId(5) val encryptionKey: String? = null
 )
 
 // Used for the deserialization on KitKat devices.


### PR DESCRIPTION
Since the repo has upgraded the Kotlin version, the deprecated ```@Optional``` annotations can be removed on the MangaPlus extension.

Also, as discussed on #1654, @arkon, do you think you can add the ```kotlinx.serialization``` and the ```kotlinx-serialization-runtime``` dependencies to the main app, so we can change the ```implementation``` on MangaPlus' Gradle to ```compileOnly``` after a while when a new stable version of the app is released?