### PR TITLE
Fix Japscan

### DIFF
--- a/src/fr/japscan/build.gradle
+++ b/src/fr/japscan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Japscan'
     pkgNameSuffix = 'fr.japscan'
     extClass = '.Japscan'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -209,8 +209,7 @@ class Japscan : ParsedHttpSource() {
         val imageScrambled = if (!document.select("script[src^='/js/iYFbYi_U']").isNullOrEmpty()) "&decodeImage" else ""
 
         document.select("select#pages").first()?.select("option")?.forEach {
-            val url = it.attr("data-img")
-            if (url.startsWith("http")) imagePath = ""
+            if (it.attr("data-img").startsWith("http")) imagePath = ""
             pages.add(Page(pages.size, "", "$imagePath${it.attr("data-img")}$imageScrambled"))
         }
 

--- a/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
+++ b/src/fr/japscan/src/eu/kanade/tachiyomi/extension/fr/japscan/Japscan.kt
@@ -88,7 +88,7 @@ class Japscan : ParsedHttpSource() {
                     .replace("[\\W]".toRegex(), "-")
                     .replace("[-]{2,}".toRegex(), "-")
                     .replace("^-|-$".toRegex(), "")
-            manga.thumbnail_url = "$baseUrl/imgs/mangas/$s.jpg"
+            manga.thumbnail_url = "$baseUrl/imgs/mangas/$s.jpg".toLowerCase()
         }
         return manga
     }
@@ -205,11 +205,13 @@ class Japscan : ParsedHttpSource() {
 
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
-        val imagePath = "(.*\\/).*".toRegex().find(document.select("#image").attr("data-src"))
+        var imagePath = "(.*\\/).*".toRegex().find(document.select("#image").attr("data-src"))?.groupValues?.get(1)
         val imageScrambled = if (!document.select("script[src^='/js/iYFbYi_U']").isNullOrEmpty()) "&decodeImage" else ""
 
         document.select("select#pages").first()?.select("option")?.forEach {
-            pages.add(Page(pages.size, "", "${imagePath?.groupValues?.get(1)}${it.attr("data-img")}$imageScrambled"))
+            val url = it.attr("data-img")
+            if (url.startsWith("http")) imagePath = ""
+            pages.add(Page(pages.size, "", "$imagePath${it.attr("data-img")}$imageScrambled"))
         }
 
         return pages


### PR DESCRIPTION
Fixes #2125 

I'm not totally sure what encoding measures that japscan has in place so I tried not to mess with it too much.

- The data url as part of the page list (options) are already an absolute url currently. (not sure what it was before.) Fixed it so there is no duplicate path interted. 
- Also fixed thumbnail urls which was broken for me because the img files were case sensitive for whatever reason. 