### PR TITLE
Fix Gufeng Manhua Search

### DIFF
--- a/src/zh/gufengmh/build.gradle
+++ b/src/zh/gufengmh/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Gufeng Manhua'
     pkgNameSuffix = 'zh.gufengmh'
     extClass = '.Gufengmh'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/zh/gufengmh/src/eu/kanade/tachiyomi/extension/zh/gufengmh/Gufengmh.kt
+++ b/src/zh/gufengmh/src/eu/kanade/tachiyomi/extension/zh/gufengmh/Gufengmh.kt
@@ -46,6 +46,7 @@ class Gufengmh : ParsedHttpSource() {
         val uri = Uri.parse(baseUrl).buildUpon()
         if (query.isNotBlank()) {
             uri.appendPath("search")
+                .appendEncodedPath("")
                 .appendQueryParameter("keywords", query)
                 .appendQueryParameter("page", page.toString())
         } else {


### PR DESCRIPTION
Fixes #2140

I noticed it on the filter list but the path generated is `/search?keyword=query` while the site specifically requires `/search/?keyword=query`