### PR TITLE
Genkan - add Reaper Scans

### DIFF
--- a/src/all/genkan/build.gradle
+++ b/src/all/genkan/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Genkan (multiple sources)'
     pkgNameSuffix = 'all.genkan'
     extClass = '.GenkanFactory'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 

--- a/src/all/genkan/src/eu/kanade/tachiyomi/extension/all/genkan/GenkanFactory.kt
+++ b/src/all/genkan/src/eu/kanade/tachiyomi/extension/all/genkan/GenkanFactory.kt
@@ -9,11 +9,10 @@ class GenkanFactory : SourceFactory {
         LeviatanScansES(),
         PsychoPlay(),
         OneShotScans(),
-        KaguyaDex(),
-        KomiScans(),
         HunlightScans(),
         WoweScans(),
-        ZeroScans()
+        ZeroScans(),
+        ReaperScans()
     )
 }
 
@@ -29,3 +28,5 @@ class KomiScans : GenkanOriginal("Komi Scans", "https://komiscans.com", "en")
 class HunlightScans : Genkan("Hunlight Scans", "https://hunlight-scans.info", "en")
 class WoweScans : Genkan("Wowe Scans", "https://wowescans.co", "en")
 class ZeroScans : Genkan("ZeroScans", "https://zeroscans.com", "en")
+// Search isn't working on Reaper's website, use GenkanOriginal for now
+class ReaperScans : GenkanOriginal("Reaper Scans", "https://reaperscans.com", "en")


### PR DESCRIPTION
Also, removed KaguyaDex and KomiScans - both websites have been unreachable for quite a while.