### PR TITLE
Pufei Domain Update

### DIFF
--- a/src/zh/pufei/build.gradle
+++ b/src/zh/pufei/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Pufei'
     pkgNameSuffix = 'zh.pufei'
     extClass = '.Pufei'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/zh/pufei/src/eu/kanade/tachiyomi/extension/zh/pufei/Pufei.kt
+++ b/src/zh/pufei/src/eu/kanade/tachiyomi/extension/zh/pufei/Pufei.kt
@@ -42,7 +42,7 @@ fun ByteArray.toHexString() = joinToString("%") { "%02x".format(it) }
 class Pufei : ParsedHttpSource() {
 
     override val name = "扑飞漫画"
-    override val baseUrl = "http://m.pufei.net"
+    override val baseUrl = "http://m.ipufei.com"
     override val lang = "zh"
     override val supportsLatest = true
     val imageServer = "http://res.img.pufei.net/"


### PR DESCRIPTION
Pufei's domain got updated. I noticed it when I was running logs and testing out why the search doesn't work. 

So, this fixes #2156

They are still redirecting pufei.net to the new one. I tried updating the imgage server but it broke more than I wanted to handle so I left it as is. Not sure when it will stop working if they let .net expire. 