### PR TITLE
Manga Park - chapter list preferences

### DIFF
--- a/src/en/mangapark/build.gradle
+++ b/src/en/mangapark/build.gradle
@@ -5,8 +5,13 @@ ext {
     appName = 'Tachiyomi: MangaPark'
     pkgNameSuffix = 'en.mangapark'
     extClass = '.MangaPark'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
+}
+
+dependencies {
+    compileOnly project(':preference-stub')
+    compileOnly 'com.github.inorichi.injekt:injekt-core:65b0440'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
+++ b/src/en/mangapark/src/eu/kanade/tachiyomi/extension/en/mangapark/MangaPark.kt
@@ -1,22 +1,34 @@
 package eu.kanade.tachiyomi.extension.en.mangapark
 
+import android.annotation.SuppressLint
+import android.app.Application
+import android.content.SharedPreferences
+import android.support.v7.preference.ListPreference
+import android.support.v7.preference.PreferenceScreen
 import android.net.Uri
 import eu.kanade.tachiyomi.network.GET
+import eu.kanade.tachiyomi.source.ConfigurableSource
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import eu.kanade.tachiyomi.util.asJsoup
 import okhttp3.Request
+import okhttp3.Response
 import org.json.JSONArray
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import uy.kohesive.injekt.Injekt
+import uy.kohesive.injekt.api.get
 import java.text.SimpleDateFormat
 import java.util.Calendar
 import java.util.Locale
+import kotlin.math.absoluteValue
 
-class MangaPark : ParsedHttpSource() {
+
+class MangaPark : ConfigurableSource, ParsedHttpSource() {
 
     override val lang = "en"
 
@@ -75,9 +87,10 @@ class MangaPark : ParsedHttpSource() {
         val coverElement = element.getElementsByClass("cover").first()
         url = coverElement.attr("href")
         title = coverElement.attr("title")
+        thumbnail_url = coverElement.select("img").attr("abs:src")
     }
 
-
+    @SuppressLint("DefaultLocale")
     override fun mangaDetailsParse(document: Document) = SManga.create().apply {
         val coverElement = document.select(".cover > img").first()
 
@@ -86,8 +99,7 @@ class MangaPark : ParsedHttpSource() {
         thumbnail_url = cleanUrl(coverElement.attr("src"))
 
         document.select(".attr > tbody > tr").forEach {
-            val type = it.getElementsByTag("th").first().text().trim().toLowerCase()
-            when (type) {
+            when (it.getElementsByTag("th").first().text().trim().toLowerCase()) {
                 "author(s)" -> {
                     author = it.getElementsByTag("a").joinToString(transform = Element::text)
                 }
@@ -109,20 +121,58 @@ class MangaPark : ParsedHttpSource() {
 
         description = document.getElementsByClass("summary").text().trim()
     }
+    
+    override fun chapterListParse(response: Response): List<SChapter> {
+        fun List<SChapter>.getMissingChapters(allChapters: List<SChapter>): List<SChapter> {
+            val chapterNums = this.map { it.chapter_number }
+            return allChapters.filter { it.chapter_number !in chapterNums }.distinctBy { it.chapter_number }
+        }
 
-    //TODO MangaPark has "versioning"
-    //TODO Previously we just use the version that is expanded by default however this caused an issue when a manga didnt have an expanded version
-    //TODO if we just choose one to expand it will cause potential missing chapters
-    //TODO right now all versions are combined so no chapters are missed
-    //TODO Maybe make it possible for users to view the other versions as well?
-    override fun chapterListSelector() = ".stream .volume .chapter li"
+        fun List<SChapter>.filterOrAll(source: String): List<SChapter>{
+            val chapters = this.filter { it.scanlator!!.contains(source) }
+            return if (chapters.isNotEmpty()) {
+                (chapters + chapters.getMissingChapters(this)).sortedByDescending { it.chapter_number }
+            } else {
+                this
+            }
+        }
 
-    override fun chapterFromElement(element: Element) = SChapter.create().apply {
-        url = element.select(".tit > a").first().attr("href").replaceAfterLast("/", "")
-        name = element.select(".tit > a").first().text()
-        date_upload = parseDate(element.select(".time").first().text().trim())
+        val mangaBySource = response.asJsoup().select("div[id^=stream]").map { sourceElement ->
+            sourceElement.select(chapterListSelector()).map { chapterFromElement(it, sourceElement.select("i + span").text()) }
+        }
+        return when (getSourcePref()) {
+            // source with most chapters along with chapters that source doesn't have
+            1 -> {
+                val chapters = mangaBySource.maxBy { it.count() }!!
+                (chapters + chapters.getMissingChapters(mangaBySource.flatten())).sortedByDescending { it.chapter_number }
+            }
+            // "smart list" - try not to miss a chapter and avoid dupes
+            2 -> mangaBySource.flatten().distinctBy { it.chapter_number }.sortedByDescending { it.chapter_number }
+            // use a specific source + any missing chapters, display all if none available from that source
+            3 -> mangaBySource.flatten().filterOrAll("Rock")
+            4 -> mangaBySource.flatten().filterOrAll("Duck")
+            5 -> mangaBySource.flatten().filterOrAll("Mini")
+            6 -> mangaBySource.flatten().filterOrAll("Fox")
+            7 -> mangaBySource.flatten().filterOrAll("Panda")
+            // all sources, all chapters
+            else -> mangaBySource.flatten()
+        }
     }
 
+    override fun chapterListSelector() = ".volume .chapter li"
+
+    private fun chapterFromElement(element: Element, source: String) = SChapter.create().apply {
+        url = element.select(".tit > a").first().attr("href").replaceAfterLast("/", "")
+        name = element.select(".tit > a").first().text()
+        // Get the chapter number or create a unique one if it's not available
+        chapter_number = Regex("""\b\d+\.?\d?\b""").find(name)?.value?.toFloatOrNull() ?: ".${name.hashCode().absoluteValue}".toFloat()
+        date_upload = parseDate(element.select(".time").first().text().trim())
+        scanlator = source
+    }
+
+    override fun chapterFromElement(element: Element): SChapter = throw UnsupportedOperationException("Not used")
+
+    @SuppressLint("DefaultLocale")
     private fun parseDate(date: String): Long {
         val lcDate = date.toLowerCase()
         if (lcDate.endsWith("ago")) return parseRelativeDate(lcDate)
@@ -331,8 +381,8 @@ class MangaPark : ParsedHttpSource() {
             GenreFilter("zombies", "Zombies")
     )), UriFilter {
         override fun addToUri(uri: Uri.Builder) {
-            uri.appendQueryParameter("genres", state.filter { it.isIncluded() }.map { it.uriParam }.joinToString(","))
-            uri.appendQueryParameter("genres-exclude", state.filter { it.isExcluded() }.map { it.uriParam }.joinToString(","))
+            uri.appendQueryParameter("genres", state.filter { it.isIncluded() }.joinToString(",") { it.uriParam })
+            uri.appendQueryParameter("genres-exclude", state.filter { it.isExcluded() }.joinToString(",") { it.uriParam })
         }
     }
 
@@ -419,4 +469,51 @@ class MangaPark : ParsedHttpSource() {
         fun addToUri(uri: Uri.Builder)
     }
 
+    // Preferences
+
+    private val preferences: SharedPreferences by lazy {
+        Injekt.get<Application>().getSharedPreferences("source_$id", 0x0000)
+    }
+
+    override fun setupPreferenceScreen(screen: androidx.preference.PreferenceScreen) {
+        val myPref = androidx.preference.ListPreference(screen.context).apply {
+            key = SOURCE_PREF_TITLE
+            title = SOURCE_PREF_TITLE
+            entries = arrayOf("All sources, all chapters", "Source with most chapters", "Smart list", "Prioritize source: Rock",
+                "Prioritize source: Duck", "Prioritize source: Mini", "Prioritize source: Fox", "Prioritize source: Panda")
+            entryValues = arrayOf("0", "1", "2", "3", "4", "5", "6", "7")
+            summary = "%s"
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val selected = newValue as String
+                val index = this.findIndexOfValue(selected)
+                preferences.edit().putInt(SOURCE_PREF, index).commit()
+            }
+        }
+        screen.addPreference(myPref)
+    }
+
+    override fun setupPreferenceScreen(screen: PreferenceScreen) {
+        val myPref = ListPreference(screen.context).apply {
+            key = SOURCE_PREF_TITLE
+            title = SOURCE_PREF_TITLE
+            entries = arrayOf("All sources, all chapters", "Source with most chapters", "Smart list", "Prioritize source: Rock",
+                "Prioritize source: Duck", "Prioritize source: Mini", "Prioritize source: Fox", "Prioritize source: Panda")
+            entryValues = arrayOf("0", "1", "2", "3", "4", "5", "6", "7")
+            summary = "%s"
+
+            setOnPreferenceChangeListener { _, newValue ->
+                val selected = newValue as String
+                val index = this.findIndexOfValue(selected)
+                preferences.edit().putInt(SOURCE_PREF, index).commit()
+            }
+        }
+        screen.addPreference(myPref)
+    }
+    private fun getSourcePref(): Int = preferences.getInt(SOURCE_PREF, 0)
+    
+    companion object {
+        private const val SOURCE_PREF_TITLE = "Chapter List Source Pref"
+        private const val SOURCE_PREF = "Manga_Park_Source_Pref"
+    }
 }


### PR DESCRIPTION
Users can now filter their chapter lists.  The default is to show all sources and all chapters; which is what users see currently.  Other options are to show:

- Source with most chapters (plus any chapters that source doesn't have but others do)

- Smart list (try not to show duplicate chapters, no specific source is prioritized)

- Source priority (show only a specific source plus any chapters that source is missing; if a manga doesn't have any chapters from the prioritized source then all sources are shown).

I may have missed some of the source/scanlator names, but I didn't want to spend more time hunting down what those may be.  It'll be easy enough to add more if needed.