### PR TITLE
Fix MangaLib Title Fetch

### DIFF
--- a/src/ru/libmanga/build.gradle
+++ b/src/ru/libmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaLib'
     pkgNameSuffix = 'ru.libmanga'
     extClass = '.LibManga'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
+++ b/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
@@ -179,7 +179,7 @@ class LibManga : ConfigurableSource, HttpSource() {
             return manga
         }
         val body = document.select("div.section__body").first()
-        manga.title = body.select(".manga-title h1").text()
+        manga.title = document.select(".manga-title h1").text()
         manga.thumbnail_url = body.select(".manga__cover").attr("src")
         manga.author = body.select(".info-list__row:nth-child(2) > a").text()
         manga.artist = body.select(".info-list__row:nth-child(3) > a").text()

--- a/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
+++ b/src/ru/libmanga/src/eu/kanade/tachiyomi/extension/ru/libmanga/LibManga.kt
@@ -179,7 +179,7 @@ class LibManga : ConfigurableSource, HttpSource() {
             return manga
         }
         val body = document.select("div.section__body").first()
-        manga.title = body.select(".manga__title").text()
+        manga.title = body.select(".manga-title h1").text()
         manga.thumbnail_url = body.select(".manga__cover").attr("src")
         manga.author = body.select(".info-list__row:nth-child(2) > a").text()
         manga.artist = body.select(".info-list__row:nth-child(3) > a").text()


### PR DESCRIPTION
Fixes #2173

Used vpn via Serbia
Title isn't actually part of "body" so I switched it to document and updated the selector 

Validated selector via try.jsoup.org and log.i

It does however return a Russian title rather than the English which is what they have on top of the manga page. 