### PR TITLE
Pufei imgdomain

### DIFF
--- a/src/zh/pufei/build.gradle
+++ b/src/zh/pufei/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Pufei'
     pkgNameSuffix = 'zh.pufei'
     extClass = '.Pufei'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/zh/pufei/src/eu/kanade/tachiyomi/extension/zh/pufei/Pufei.kt
+++ b/src/zh/pufei/src/eu/kanade/tachiyomi/extension/zh/pufei/Pufei.kt
@@ -45,7 +45,7 @@ class Pufei : ParsedHttpSource() {
     override val baseUrl = "http://m.ipufei.com"
     override val lang = "zh"
     override val supportsLatest = true
-    val imageServer = "http://res.img.ipufei.com/"
+    val imageServer = "http://res.img.220012.net/"  //Alternative: "http://res.img.ipufei.com/"
 
     override fun popularMangaSelector() = "ul#detail li"
 

--- a/src/zh/pufei/src/eu/kanade/tachiyomi/extension/zh/pufei/Pufei.kt
+++ b/src/zh/pufei/src/eu/kanade/tachiyomi/extension/zh/pufei/Pufei.kt
@@ -45,7 +45,7 @@ class Pufei : ParsedHttpSource() {
     override val baseUrl = "http://m.ipufei.com"
     override val lang = "zh"
     override val supportsLatest = true
-    val imageServer = "http://res.img.pufei.net/"
+    val imageServer = "http://res.img.ipufei.com/"
 
     override fun popularMangaSelector() = "ul#detail li"
 


### PR DESCRIPTION
Fixes #2182 

I thought it wasn't working when I tested it as I was working on the previous PR. 
Retesting it again, it seems to be working. 

Inspecting the webpage shows that it points to `http://res.img.220012.net/`
As inferred from the previous entry, `http://res.img.ipufei.com` also works but I decided to mirror what they have now via. 
