### PR TITLE
MangaHasu - Fix Placeholder Images

### DIFF
--- a/src/en/mangahasu/build.gradle
+++ b/src/en/mangahasu/build.gradle
@@ -5,8 +5,13 @@ ext {
     appName = 'Tachiyomi: Mangahasu'
     pkgNameSuffix = 'en.mangahasu'
     extClass = '.Mangahasu'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
+}
+
+dependencies {
+    compileOnly 'com.google.code.gson:gson:2.8.5'
+    compileOnly 'com.github.salomonbrys.kotson:kotson:2.5.0'
 }
 
 apply from: "$rootDir/common.gradle"


### PR DESCRIPTION
Fixes #1548
Find and replace placeholder images on new chapters. 

MangaHasu is ripping from Mangadex. There are temporary urls that are encoded json file before the images are fully loaded onto the MangaHasu servers. These images are scrapped as "Loading". 

This PR now decodes the json file and replaces the "Loading" images similar to what normally happens in the browser. 

