### PR TITLE
Update Lector

### DIFF
--- a/src/es/lectormanga/build.gradle
+++ b/src/es/lectormanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: LectorManga'
     pkgNameSuffix = 'es.lectormanga'
     extClass = '.LectorManga'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Addresses #2256 but doesn't really fix what causes it. 

- Add a successful check / http error message before throwing catch all.
- Changes second catch all error message to specifically reference source
- Fixes page filtering where it was dropping a few of the first pages
