### PR TITLE
Refactor / Fix Manga.ae

### DIFF
--- a/src/ar/mangaae/build.gradle
+++ b/src/ar/mangaae/build.gradle
@@ -5,8 +5,12 @@ ext {
     appName = 'Tachiyomi: Manga.ae'
     pkgNameSuffix = 'ar.mangaae'
     extClass = '.MangaAe'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
+}
+
+dependencies {
+    implementation project(':lib-ratelimit')
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/ar/mangaae/src/eu/kanade/tachiyomi/extension/ar/mangaae/MangaAe.kt
+++ b/src/ar/mangaae/src/eu/kanade/tachiyomi/extension/ar/mangaae/MangaAe.kt
@@ -1,9 +1,10 @@
 package eu.kanade.tachiyomi.extension.ar.mangaae
 
-import android.util.Log
+import eu.kanade.tachiyomi.lib.ratelimit.RateLimitInterceptor
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
+import okhttp3.Headers
 import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -20,26 +21,33 @@ class MangaAe : ParsedHttpSource() {
 
     override val supportsLatest = true
 
-    override val client: OkHttpClient = network.cloudflareClient
+    private val rateLimitInterceptor = RateLimitInterceptor(2)
+
+    override val client: OkHttpClient = network.cloudflareClient.newBuilder()
+        .addNetworkInterceptor(rateLimitInterceptor)
+        .build()
+
+    override fun headersBuilder(): Headers.Builder = Headers.Builder()
+        .add("User-Agent", "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:54.0) Gecko/20100101 Firefox/73.0")
+        .add("Referer", baseUrl)
 
     // Popular
     override fun popularMangaRequest(page: Int): Request {
-        return GET("$baseUrl/manga", headers)
+        return GET("$baseUrl/manga/page:$page", headers)
     }
+
+    override fun popularMangaNextPageSelector() = "div.pagination a:last-child:not(.active)"
 
     override fun popularMangaSelector() = "div.mangacontainer"
 
-    override fun popularMangaFromElement(element: Element): SManga {
-        val manga = SManga.create()
-        manga.thumbnail_url = element.select("img").first().attr("src")
-        element.select("a.manga")[1].let {
-            manga.setUrlWithoutDomain(it.attr("href"))
-            manga.title = it.text()
+    override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
+        val lazysrc = element.select("img").attr("data-pagespeed-lazy-src")
+        thumbnail_url = if (lazysrc.isNullOrEmpty()) { element.select("img").attr("src") } else { lazysrc }
+        element.select("div.mangacontainer a.manga")[0].let {
+            title = it.text()
+            setUrlWithoutDomain(it.attr("abs:href"))
         }
-        return manga
     }
-
-    override fun popularMangaNextPageSelector() = "div.pagination a.active"
 
     // Latest
     override fun latestUpdatesRequest(page: Int): Request {
@@ -48,16 +56,13 @@ class MangaAe : ParsedHttpSource() {
 
     override fun latestUpdatesSelector(): String = "div.popular-manga-container"
 
-    override fun latestUpdatesFromElement(element: Element): SManga {
-        val manga = SManga.create()
-        val img = element.select("img").first()
-        element.select("a").first().let {
-            manga.setUrlWithoutDomain(it.attr("href"))
-            manga.title = img.attr("alt")
-                .split("مانجا ")[1].split(" ch")[0]
+    override fun latestUpdatesFromElement(element: Element): SManga = SManga.create().apply {
+        val lazysrc = element.select("img").attr("data-pagespeed-lazy-src")
+        thumbnail_url = if (lazysrc.isNullOrEmpty()) { element.select("img").attr("src") } else { lazysrc }
+        element.select("a")[2].let {
+            setUrlWithoutDomain(it.attr("abs:href"))
+            title = it.text()
         }
-        manga.thumbnail_url = img.attr("src")
-            return manga
     }
 
     override fun latestUpdatesNextPageSelector(): String? = null
@@ -85,18 +90,15 @@ class MangaAe : ParsedHttpSource() {
     override fun searchMangaNextPageSelector() = popularMangaNextPageSelector()
 
     // Manga summary page
-    override fun mangaDetailsParse(document: Document): SManga {
+    override fun mangaDetailsParse(document: Document): SManga = SManga.create().apply {
         val infoElement = document.select("div.indexcontainer").first()
-        val manga = SManga.create()
-        manga.title = infoElement.select("div.main").first().ownText()
-        manga.author = infoElement.select("div.manga-details-author a")[1].ownText()
-        val status = infoElement.select("div.manga-details-extended h4")[1].ownText()
-        manga.status = parseStatus(status)
-        manga.genre = infoElement.select("ul > li").mapNotNull{ it.text() }.joinToString(", ")
-        manga.description = infoElement.select("div.manga-details-extended h4")[2].ownText()
-        manga.thumbnail_url = infoElement.select("img.manga-cover").attr("src")
-
-        return manga
+        title = infoElement.select("h1.EnglishName").text().removeSurrounding("(",")")
+        author = infoElement.select("div.manga-details-author h4")[0].text()
+        artist = author
+        status = parseStatus(infoElement.select("div.manga-details-extended h4")[1].text())
+        genre = infoElement.select("div.manga-details-extended a[href*=tag]").map { it.text() }.joinToString(", ")
+        description = infoElement.select("div.manga-details-extended h4")[2].text()
+        thumbnail_url = infoElement.select("img.manga-cover").attr("src")
     }
 
     private fun parseStatus(status: String?) = when {
@@ -115,10 +117,8 @@ class MangaAe : ParsedHttpSource() {
             // use full pages for easier links
             chapter.setUrlWithoutDomain(it.attr("href")
                 .replace("/1/", "/0/full"))
-            chapter.name = it.text()
+            chapter.name = "\u061C" + it.text() //Add unicode ARABIC LETTER MARK to ensure all titles are right to left
         }
-        chapter.date_upload = 0
-
         return chapter
     }
 


### PR DESCRIPTION
Change Log (from top to bottom)

- Added Rate Limiting and new headers as an attempt to address #1963. I think this reduces the risk and rate of a possible server side trigger that causes pages to be blocked. 

Popular
- Added pages to popular and fixed next page selector
- Changed Arabic names to English to make names uniform across the extension. Also helps if you wish to migrate to a different extension I think.
- Fixed broken thumbnails

Latest
- Fixed url selection #2268

Details
- Refactored while I was at it.

Chapter List
- Added a arabic Unicode marker to ensure all text is right to left due to mixed text (Some titles contain only numbers while some other contain arabic titles) 

