### PR TITLE
Holy/Heaven Manga - Update baseUrl

### DIFF
--- a/src/en/holymanga/build.gradle
+++ b/src/en/holymanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: HolyManga & HeavenManga'
     pkgNameSuffix = 'en.holymanga'
     extClass = '.HMangaFactory'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/en/holymanga/src/eu/kanade/tachiyomi/extension/en/holymanga/HMangaFactory.kt
+++ b/src/en/holymanga/src/eu/kanade/tachiyomi/extension/en/holymanga/HMangaFactory.kt
@@ -10,6 +10,6 @@ class HMangaFactory : SourceFactory {
     )
 }
 
-class HolyManga : HManga("HolyManga", "https://holymanga.net")
-class HeavenManga : HManga("HeavenManga", "https://heavenmanga.org")
+class HolyManga : HManga("HolyManga", "http://w12.holymanga.net")
+class HeavenManga : HManga("HeavenManga", "http://ww8.heavenmanga.org")
 


### PR DESCRIPTION
Hopefully closes #2263 

I was not able to reproduce the "No Results Found" error code but I did notice that there was a chain of redirects which causes an error bypassing cloudflare.

Example:
`https://heavenmanga.org` redirects to `http://ww7.heavenmanga.org` which then redirects to `http://ww8.heavenmanga.org` each triggering cloudflare checks again. 

Updated baseUrl and tested on dev and stable that basic functions were working. 