### PR TITLE
webtoon age gate fix

### DIFF
--- a/src/all/webtoons/build.gradle
+++ b/src/all/webtoons/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Webtoons'
     pkgNameSuffix = 'all.webtoons'
     extClass = '.WebtoonsFactory'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/Webtoons.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/Webtoons.kt
@@ -19,15 +19,16 @@ abstract class Webtoons(override val lang: String, open val langCode: String = l
 
     override val client = super.client.newBuilder()
         .cookieJar(object : CookieJar {
-            override fun saveFromResponse(url: HttpUrl, cookies: MutableList<Cookie>) {}
-            override fun loadForRequest(url: HttpUrl): MutableList<Cookie> {
-                return ArrayList<Cookie>().apply {
-                    add(Cookie.Builder()
+            override fun saveFromResponse(url: HttpUrl, cookies: List<Cookie>) {}
+            override fun loadForRequest(url: HttpUrl): List<Cookie> {
+                return listOf<Cookie>(
+                    Cookie.Builder()
                         .domain("www.webtoons.com")
                         .path("/")
                         .name("ageGatePass")
                         .value("true")
-                        .build()) }
+                        .build()
+                )
             }
 
         })

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/Webtoons.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/Webtoons.kt
@@ -4,10 +4,7 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.Headers
-import okhttp3.Request
-import okhttp3.Response
-import okhttp3.HttpUrl
+import okhttp3.*
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.util.Calendar
@@ -19,6 +16,22 @@ abstract class Webtoons(override val lang: String, open val langCode: String = l
     override val baseUrl = "http://www.webtoons.com"
 
     override val supportsLatest = true
+
+    override val client = super.client.newBuilder()
+        .cookieJar(object : CookieJar {
+            override fun saveFromResponse(url: HttpUrl, cookies: MutableList<Cookie>) {}
+            override fun loadForRequest(url: HttpUrl): MutableList<Cookie> {
+                return ArrayList<Cookie>().apply {
+                    add(Cookie.Builder()
+                        .domain("www.webtoons.com")
+                        .path("/")
+                        .name("ageGatePass")
+                        .value("true")
+                        .build()) }
+            }
+
+        })
+        .build()
 
     private val day: String
         get() {


### PR DESCRIPTION
* can browse popular webtoons again

* can update webtoon chapter lists again

* can search for webtoons again

* version number updated

Webtoon implemented an age gate that interfered with scraping.

We now have to send a cookie with every request to make it work again.

I've used code from commit #1029 which fixed a similar issue.

Finding the problem, adapting the fix and testing it is what I did.