### PR TITLE
MangAdventure: support custom chapter titles

### DIFF
--- a/src/all/mangadventure/build.gradle
+++ b/src/all/mangadventure/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangAdventure'
     pkgNameSuffix = 'all.mangadventure'
     extClass = '.MangAdventureFactory'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 

--- a/src/all/mangadventure/src/eu/kanade/tachiyomi/extension/all/mangadventure/MangAdventure.kt
+++ b/src/all/mangadventure/src/eu/kanade/tachiyomi/extension/all/mangadventure/MangAdventure.kt
@@ -122,7 +122,7 @@ abstract class MangAdventure(
                         }
                     )
                 }
-            }.sortedByDescending(SChapter::name).toList()
+            }.toList().reversed()
         }
 
     override fun mangaDetailsParse(response: Response) =
@@ -131,7 +131,9 @@ abstract class MangAdventure(
     override fun pageListParse(response: Response) =
         JSONObject(response.asString()).run {
             val url = getString("url")
+            // Workaround for a bug in MangAdventure < 0.6.3
             val root = getString("pages_root")
+                .replace("://media/series", "://reader")
             val arr = getJSONArray("pages_list")
             (0 until arr.length()).map {
                 Page(it, "$url${it + 1}", "$root${arr.getString(it)}")

--- a/src/all/mangadventure/src/eu/kanade/tachiyomi/extension/all/mangadventure/MangAdventureExtensions.kt
+++ b/src/all/mangadventure/src/eu/kanade/tachiyomi/extension/all/mangadventure/MangAdventureExtensions.kt
@@ -72,10 +72,10 @@ fun SChapter.fromJSON(obj: JSONObject) = apply {
     chapter_number = obj.optString("chapter", "0").toFloat()
     date_upload = MangAdventure.httpDateToTimestamp(obj.getString("date"))
     scanlator = obj.getJSONArray("groups")?.joinField("name", " & ")
-    name = buildString {
-        obj.optInt("volume").let { if (it != 0) append("Vol.$it ") }
-        append("Ch.${DecimalFormat("#.#").format(chapter_number)} - ")
+    name = obj.optString("full_title", buildString {
+        obj.optInt("volume").let { if (it != 0) append("Vol. $it, ") }
+        append("Ch. ${DecimalFormat("#.#").format(chapter_number)}: ")
         append(obj.getString("title"))
-        if (obj.getBoolean("final")) append(" [END]")
-    }
+    })
+    if (obj.getBoolean("final")) name += " [END]"
 }


### PR DESCRIPTION
MangAdventure introduced custom chapter titles (e.g. `Z={number}: {title}`) in `v0.6.4`.
The extension will now use that title and fall back to a generic format if it's not available.

This also fixes a bug in older versions of the API.

---

P.S. @SnakeDoc83 MangAdventure should be moved to the multi-source tab of your spreadsheet. 