### PR TITLE
Guya: Add support for opening guya.moe titles directly in Tachiyomi

### DIFF
--- a/src/en/guya/AndroidManifest.xml
+++ b/src/en/guya/AndroidManifest.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+                android:name=".GuyaUrlActivity"
+                android:theme="@android:style/Theme.NoDisplay"
+                android:excludeFromRecents="true">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                        android:scheme="https"
+                        android:host="guya.moe"
+                        android:pathPattern="/read/manga/..*" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/en/guya/build.gradle
+++ b/src/en/guya/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Guya'
     pkgNameSuffix = "en.guya"
     extClass = '.Guya'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/en/guya/src/eu/kanade/tachiyomi/extension/en/guya/GuyaUrlActivity.kt
+++ b/src/en/guya/src/eu/kanade/tachiyomi/extension/en/guya/GuyaUrlActivity.kt
@@ -1,0 +1,44 @@
+package eu.kanade.tachiyomi.extension.en.guya
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+/**
+ * Accepts https://guya.moe/read/manga/xyz intents
+ *
+ * Added due to requests from various users to allow for opening of titles when given the
+ * Guya URL whilst on mobile.
+ */
+class GuyaUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size == 3) {
+            val slug = pathSegments[2]
+
+            // Gotta do it like this since slug title != actual title
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", "${Guya.SLUG_PREFIX}$slug")
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("GuyaUrlActivity", e.toString())
+            }
+        } else {
+            Log.e("GuyaUrlActivity", "Unable to parse URI from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+
+}


### PR DESCRIPTION
At the request of some users, added support for directly opening manga from the `https://guya.moe/read/manga/*` URL.