### PR TITLE
MangaFree - Remove https

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 

--- a/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBoxFactory.kt
+++ b/src/all/mangabox/src/eu/kanade/tachiyomi/extension/all/mangabox/MangaBoxFactory.kt
@@ -43,7 +43,7 @@ class Manganelo : MangaBox("Manganelo", "https://manganelo.com", "en") {
     override fun getFilterList() = FilterList()
 }
 
-class Mangafree : MangaBox("Mangafree", "https://mangafree.online", "en") {
+class Mangafree : MangaBox("Mangafree", "http://mangafree.online", "en") {
     override val popularUrlPath = "hotmanga/"
     override val latestUrlPath = "latest/"
     override fun popularMangaParse(response: Response): MangasPage {


### PR DESCRIPTION
Reported on Discord:

MangaFree doesn't support https 
`Unable to connect` / refused connection. 