### PR TITLE
Kiss Manga - Add thumbnails to MangaFromElement

### DIFF
--- a/src/en/kissmanga/build.gradle
+++ b/src/en/kissmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Kissmanga'
     pkgNameSuffix = 'en.kissmanga'
     extClass = '.Kissmanga'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
+++ b/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
@@ -40,7 +40,7 @@ class Kissmanga : ParsedHttpSource() {
     }
 
     override fun latestUpdatesRequest(page: Int): Request {
-        return GET("https://kissmanga.com/MangaList/LatestUpdate?page=$page", headers)
+        return GET("$baseUrl/MangaList/LatestUpdate?page=$page", headers)
     }
 
     override fun popularMangaFromElement(element: Element): SManga {

--- a/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
+++ b/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
@@ -44,6 +44,7 @@ class Kissmanga : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
+        manga.thumbnail_url = element.select("td").attr("title").substringAfter("src=\"").substringBefore("\"")
         element.select("td a:eq(0)").first().let {
             manga.setUrlWithoutDomain(it.attr("href"))
             val title = it.text()

--- a/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
+++ b/src/en/kissmanga/src/eu/kanade/tachiyomi/extension/en/kissmanga/Kissmanga.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import okhttp3.*
+import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -44,7 +45,7 @@ class Kissmanga : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga {
         val manga = SManga.create()
-        manga.thumbnail_url = element.select("td").attr("title").substringAfter("src=\"").substringBefore("\"")
+        manga.thumbnail_url = Jsoup.parseBodyFragment(element.select("td").attr("title")).select("img").attr("abs:src")
         element.select("td a:eq(0)").first().let {
             manga.setUrlWithoutDomain(it.attr("href"))
             val title = it.text()


### PR DESCRIPTION
Covers were included in the tool tip info so we can add thumbnails to the initial manga load in popular / latest / search. 