### PR TITLE
[MangaDex] Adding Manga language to list of genres

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 83
+    extVersionCode = 84
     libVersion = '1.2'
 }
 

--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -395,7 +395,8 @@ abstract class Mangadex(
         }
 
         val genres = (if (mangaJson.get("hentai").int == 1) listOf("Hentai") else listOf()) +
-            mangaJson.get("genres").asJsonArray.mapNotNull { GENRES[it.toString()] }
+            mangaJson.get("genres").asJsonArray.mapNotNull { GENRES[it.toString()] } +
+            mangaJson.get("lang_name").string
         manga.genre = genres.joinToString(", ")
 
         return manga


### PR DESCRIPTION
I needed this for filtering, plus you can see it as a way for user to tell the origin of a manga/comic/manhwa/thing