### PR TITLE
E-Hentai added Watched list

### DIFF
--- a/src/all/ehentai/build.gradle
+++ b/src/all/ehentai/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: E-Hentai'
     pkgNameSuffix = 'all.ehentai'
     extClass = '.EHFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHentai.kt
+++ b/src/all/ehentai/src/eu/kanade/tachiyomi/extension/all/ehentai/EHentai.kt
@@ -280,9 +280,16 @@ open class EHentai(override val lang: String, private val ehLang: String) : Http
 
     //Filters
     override fun getFilterList() = FilterList(
+        Watched(),
         GenreGroup(),
         AdvancedGroup()
     )
+    
+    class Watched : Filter.CheckBox("Watched List"), UriFilter {
+        override fun addToUri(builder: Uri.Builder) {
+            builder.appendPath("watched")
+        }
+    }
 
     class GenreOption(name: String, private val genreId: String) : Filter.CheckBox(name, false), UriFilter {
         override fun addToUri(builder: Uri.Builder) {


### PR DESCRIPTION
Allows you to use the E-Hentai watched page to view a listing of your watched tags
- Requires you be logged in with webview
- Watched tags have have to be edited in webview or on a browser
- Power threshold is changed in the webview, in the E-Hentai Settings for your account