### PR TITLE
Change MangasProject name to the new one

### DIFF
--- a/src/pt/mangasproject/build.gradle
+++ b/src/pt/mangasproject/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: mangásPROJECT'
     pkgNameSuffix = 'pt.mangasproject'
     extClass = '.MangasProjectFactory'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProject.kt
+++ b/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProject.kt
@@ -10,13 +10,18 @@ import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.HttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import okhttp3.*
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
 import org.jsoup.nodes.Element
 import rx.Observable
 import java.lang.Exception
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 abstract class MangasProject(override val name: String,

--- a/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProjectFactory.kt
+++ b/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProjectFactory.kt
@@ -5,10 +5,17 @@ import eu.kanade.tachiyomi.source.SourceFactory
 
 class MangasProjectFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
-        MangasProjectOriginal(),
+        LeitorNet(),
         MangaLivre()
     )
 }
 
-class MangasProjectOriginal : MangasProject("mangásPROJECT", "https://leitor.net")
+class LeitorNet : MangasProject("Leitor.net", "https://leitor.net") {
+    // Use the old generated id when the source did have the name "mangásPROJECT" and
+    // did have mangas in their catalogue. Now they "only have webtoons" and
+    // became a different website, but they still use the same structure.
+    // Existing mangas and other titles in the library still work.
+    override val id: Long = 2225174659569980836
+}
+
 class MangaLivre : MangasProject("MangaLivre", "https://mangalivre.net")


### PR DESCRIPTION
MangasProject recently changed its name to "Leitor.net" and now only lists webtoons at the initial page, becoming into a "different website". To avoid confusion, I changed the old name and hardcoded the old generated id. 

Old titles like mangas in the library still work and can be accessed at the website through the direct URL or search, so a migration isn't really necessary. Is this a good approach, or it's better to only change the `name` and bump the `versionId`, forcing the users to migrate their library to MangaLivre?