### PR TITLE
Update Kotlin and kotlinx.serialization version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.60'
+    ext.kotlin_version = '1.3.70'
     repositories {
         jcenter()
         google()

--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -6,12 +6,13 @@ ext {
     appName = 'Tachiyomi: MANGA Plus by SHUEISHA'
     pkgNameSuffix = 'all.mangaplus'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 
 dependencies {
-    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.14.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-protobuf:0.20.0'
+    implementation 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0'
     compileOnly 'com.google.code.gson:gson:2.8.2'
     compileOnly project(':duktape-stub')
 }

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -8,7 +8,14 @@ import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.HttpSource
 import kotlinx.serialization.protobuf.ProtoBuf
-import okhttp3.*
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import okhttp3.ResponseBody
 import rx.Observable
 import java.lang.Exception
 import java.util.UUID

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
@@ -1,8 +1,7 @@
 package eu.kanade.tachiyomi.extension.all.mangaplus
 
 import com.google.gson.annotations.SerializedName
-import kotlinx.serialization.Optional
-import kotlinx.serialization.SerialId
+import kotlinx.serialization.protobuf.ProtoId
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.Serializer
 
@@ -11,115 +10,115 @@ object MangaPlusSerializer
 
 @Serializable
 data class MangaPlusResponse(
-    @Optional @SerialId(1) val success: SuccessResult? = null,
-    @Optional @SerialId(2) val error: ErrorResult? = null
+    @ProtoId(1) val success: SuccessResult? = null,
+    @ProtoId(2) val error: ErrorResult? = null
 )
 
 @Serializable
 data class ErrorResult(
-    @SerialId(1) val action: Action,
-    @SerialId(2) val englishPopup: Popup,
-    @SerialId(3) val spanishPopup: Popup
+    @ProtoId(1) val action: Action,
+    @ProtoId(2) val englishPopup: Popup,
+    @ProtoId(3) val spanishPopup: Popup
 )
 
 enum class Action { DEFAULT, UNAUTHORIZED, MAINTAINENCE, GEOIP_BLOCKING }
 
 @Serializable
 data class Popup(
-    @SerialId(1) val subject: String,
-    @SerialId(2) val body: String
+    @ProtoId(1) val subject: String,
+    @ProtoId(2) val body: String
 )
 
 @Serializable
 data class SuccessResult(
-    @Optional @SerialId(1) val isFeaturedUpdated: Boolean? = false,
-    @Optional @SerialId(5) val allTitlesView: AllTitlesView? = null,
-    @Optional @SerialId(6) val titleRankingView: TitleRankingView? = null,
-    @Optional @SerialId(8) val titleDetailView: TitleDetailView? = null,
-    @Optional @SerialId(10) val mangaViewer: MangaViewer? = null,
-    @Optional @SerialId(11) val webHomeView: WebHomeView? = null
+    @ProtoId(1) val isFeaturedUpdated: Boolean? = false,
+    @ProtoId(5) val allTitlesView: AllTitlesView? = null,
+    @ProtoId(6) val titleRankingView: TitleRankingView? = null,
+    @ProtoId(8) val titleDetailView: TitleDetailView? = null,
+    @ProtoId(10) val mangaViewer: MangaViewer? = null,
+    @ProtoId(11) val webHomeView: WebHomeView? = null
 )
 
 @Serializable
-data class TitleRankingView(@SerialId(1) val titles: List<Title> = emptyList())
+data class TitleRankingView(@ProtoId(1) val titles: List<Title> = emptyList())
 
 @Serializable
-data class AllTitlesView(@SerialId(1) val titles: List<Title> = emptyList())
+data class AllTitlesView(@ProtoId(1) val titles: List<Title> = emptyList())
 
 @Serializable
-data class WebHomeView(@SerialId(2) val groups: List<UpdatedTitleGroup> = emptyList())
+data class WebHomeView(@ProtoId(2) val groups: List<UpdatedTitleGroup> = emptyList())
 
 @Serializable
 data class TitleDetailView(
-    @SerialId(1) val title: Title,
-    @SerialId(2) val titleImageUrl: String,
-    @SerialId(3) val overview: String,
-    @SerialId(4) val backgroundImageUrl: String,
-    @Optional @SerialId(5) val nextTimeStamp: Int = 0,
-    @Optional @SerialId(6) val updateTiming: UpdateTiming? = UpdateTiming.DAY,
-    @Optional @SerialId(7) val viewingPeriodDescription: String = "",
-    @SerialId(9) val firstChapterList: List<Chapter> = emptyList(),
-    @Optional @SerialId(10) val lastChapterList: List<Chapter> = emptyList(),
-    @Optional @SerialId(14) val isSimulReleased: Boolean = true,
-    @Optional @SerialId(17) val chaptersDescending: Boolean = true
+    @ProtoId(1) val title: Title,
+    @ProtoId(2) val titleImageUrl: String,
+    @ProtoId(3) val overview: String,
+    @ProtoId(4) val backgroundImageUrl: String,
+    @ProtoId(5) val nextTimeStamp: Int = 0,
+    @ProtoId(6) val updateTiming: UpdateTiming? = UpdateTiming.DAY,
+    @ProtoId(7) val viewingPeriodDescription: String = "",
+    @ProtoId(9) val firstChapterList: List<Chapter> = emptyList(),
+    @ProtoId(10) val lastChapterList: List<Chapter> = emptyList(),
+    @ProtoId(14) val isSimulReleased: Boolean = true,
+    @ProtoId(17) val chaptersDescending: Boolean = true
 )
 
 enum class UpdateTiming { NOT_REGULARLY, MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY, DAY }
 
 @Serializable
-data class MangaViewer(@SerialId(1) val pages: List<MangaPlusPage> = emptyList())
+data class MangaViewer(@ProtoId(1) val pages: List<MangaPlusPage> = emptyList())
 
 @Serializable
 data class Title(
-    @SerialId(1) val titleId: Int,
-    @SerialId(2) val name: String,
-    @SerialId(3) val author: String,
-    @SerialId(4) val portraitImageUrl: String,
-    @SerialId(5) val landscapeImageUrl: String,
-    @SerialId(6) val viewCount: Int,
-    @Optional @SerialId(7) val language: Language? = Language.ENGLISH
+    @ProtoId(1) val titleId: Int,
+    @ProtoId(2) val name: String,
+    @ProtoId(3) val author: String,
+    @ProtoId(4) val portraitImageUrl: String,
+    @ProtoId(5) val landscapeImageUrl: String,
+    @ProtoId(6) val viewCount: Int,
+    @ProtoId(7) val language: Language? = Language.ENGLISH
 )
 
 enum class Language(val id: Int) {
-    @SerialId(0)
+    @ProtoId(0)
     @SerializedName("0")
     ENGLISH(0),
 
-    @SerialId(1)
+    @ProtoId(1)
     @SerializedName("1")
     SPANISH(1)
 }
 
 @Serializable
 data class UpdatedTitleGroup(
-    @SerialId(1) val groupName: String,
-    @SerialId(2) val titles: List<UpdatedTitle> = emptyList()
+    @ProtoId(1) val groupName: String,
+    @ProtoId(2) val titles: List<UpdatedTitle> = emptyList()
 )
 
 @Serializable
 data class UpdatedTitle(
-    @Optional @SerialId(1) val title: Title? = null
+    @ProtoId(1) val title: Title? = null
 )
 
 @Serializable
 data class Chapter(
-    @SerialId(1) val titleId: Int,
-    @SerialId(2) val chapterId: Int,
-    @SerialId(3) val name: String,
-    @Optional @SerialId(4) val subTitle: String? = null,
-    @SerialId(6) val startTimeStamp: Int,
-    @SerialId(7) val endTimeStamp: Int
+    @ProtoId(1) val titleId: Int,
+    @ProtoId(2) val chapterId: Int,
+    @ProtoId(3) val name: String,
+    @ProtoId(4) val subTitle: String? = null,
+    @ProtoId(6) val startTimeStamp: Int,
+    @ProtoId(7) val endTimeStamp: Int
 )
 
 @Serializable
-data class MangaPlusPage(@Optional @SerialId(1) val page: MangaPage? = null)
+data class MangaPlusPage(@ProtoId(1) val page: MangaPage? = null)
 
 @Serializable
 data class MangaPage(
-    @SerialId(1) val imageUrl: String,
-    @SerialId(2) val width: Int,
-    @SerialId(3) val height: Int,
-    @Optional @SerialId(5) val encryptionKey: String? = null
+    @ProtoId(1) val imageUrl: String,
+    @ProtoId(2) val width: Int,
+    @ProtoId(3) val height: Int,
+    @ProtoId(5) val encryptionKey: String? = null
 )
 
 // Used for the deserialization on KitKat devices.

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
@@ -79,6 +79,7 @@ data class Title(
     @ProtoId(7) val language: Language? = Language.ENGLISH
 )
 
+@Serializable
 enum class Language(val id: Int) {
     @ProtoId(0)
     @SerializedName("0")


### PR DESCRIPTION
Update Kotlin's version to match the version used in the app (1.3.70) and the kotlinx.serialization lib.

The compiled MangaPlus apk was tested in Android 4.1 (stable), Android 5.0, 6.0 and 10.0 (stable and dev) and it's working fine with the deserialization from kotlinx.serialization.

On older devices (Android <= KitKat) the extension only works with the stable version because of some unknown incompatibility with Duktape 1.3.0 and Kotlin 1.3.70 related to the `require` function. Since the dev version isn't compatible anymore with those devices, it doesn't see to be a huge problem.

Should close #2512.