### PR TITLE
Fixed title parsing for DisasterScans's mangaDetailsParse

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 63
+    extVersionCode = 64
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -480,6 +480,18 @@ class ThreeSixtyFiveManga: Madara("365Manga","https://365manga.com","en") {
 
 class DisasterScans: Madara("Disaster Scans","https://disasterscans.com","en") {
     override val popularMangaUrlSelector = "div.post-title a:last-child"
+
+    override fun mangaDetailsParse(document: Document): SManga {
+        val manga = super.mangaDetailsParse(document)
+
+        with(document) {
+            select("div.post-title h1").first()?.let {
+                manga.title = it.ownText()
+            }
+        }
+
+        return manga
+    }
 }
 
 class MangaKiss: Madara("MangaKiss", "https://mangakiss.org", "en", SimpleDateFormat("dd/MM/yyyy", Locale.US)) {


### PR DESCRIPTION
Shouldn't really change nothing since the title _should_ already be fetched when opening the latest/popular/search page but better safe than sorry.