### PR TITLE
Added www Mangadex subdomain to open directly

### DIFF
--- a/src/all/mangadex/AndroidManifest.xml
+++ b/src/all/mangadex/AndroidManifest.xml
@@ -15,6 +15,10 @@
                     android:pathPattern="/title/..*" />
                 <data
                     android:scheme="https"
+                    android:host="www.mangadex.org"
+                    android:pathPattern="/title/..*" />
+                <data
+                    android:scheme="https"
                     android:host="mangadex.org"
                     android:pathPattern="/manga/..*" />
                 <data

--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 87
+    extVersionCode = 88
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
While Google search results lead to mangadex.org websites,
other search engines such as Duckduckgo and Bing lead to
www.mangadex.org websites.
Changed extension manifest to handle www.mangadex.org