### PR TITLE
Add missing chapters at MangasProject

### DIFF
--- a/src/pt/mangasproject/build.gradle
+++ b/src/pt/mangasproject/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: mangásPROJECT'
     pkgNameSuffix = 'pt.mangasproject'
     extClass = '.MangasProjectFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProjectFactory.kt
+++ b/src/pt/mangasproject/src/eu/kanade/tachiyomi/extension/pt/mangasproject/MangasProjectFactory.kt
@@ -18,4 +18,7 @@ class LeitorNet : MangasProject("Leitor.net", "https://leitor.net") {
     override val id: Long = 2225174659569980836
 }
 
-class MangaLivre : MangasProject("MangaLivre", "https://mangalivre.net")
+class MangaLivre : MangasProject("MangaLivre", "https://mangalivre.net") {
+    // Hardcode the id because the language wasn't specific.
+    override val id: Long = 4762777556012432014
+}


### PR DESCRIPTION
Also updated the language to `pt-BR`, hardcoding the previous `id`.

To those who update: 
- MangaLivre and Leitor.net are now under the *Português (Brasil)* category at *Sources*;
- To skip the chapters with the same number from other scanlators and prioritize the current scanlator during reading, make sure the *Sorting mode* selected is *By chapter number* at the chapter list three-dots menu.