### PR TITLE
Madara - chapters, thumbnails

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 68
+    extVersionCode = 69
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -15,8 +15,6 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
-import okhttp3.Cookie
-import okhttp3.CookieJar
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -15,6 +15,8 @@ import okhttp3.HttpUrl
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
+import okhttp3.Cookie
+import okhttp3.CookieJar
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.SimpleDateFormat
@@ -175,9 +177,6 @@ class MangazukiClubKO : Madara("Mangazuki.club", "https://mangazuki.club", "ko")
 class FirstKissManga : Madara("1st Kiss", "https://1stkissmanga.com", "en",
     dateFormat = SimpleDateFormat("dd MMM yyyy", Locale.US)) {
     override fun headersBuilder(): Headers.Builder = super.headersBuilder().add("Referer", baseUrl)
-    override fun detailsThumbnail(element: Element): String {
-        return if (element.hasAttr("data-lazy-src")) element.attr("abs:data-lazy-src") else super.detailsThumbnail(element)
-    }
 }
 
 class MangaSY : Madara("Manga SY", "https://www.mangasy.com", "en")
@@ -269,7 +268,7 @@ class Milftoon : Madara("Milftoon", "https://milftoon.xxx", "en") {
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/page/$page/?m_orderby=latest", headers)
 }
 
-class Hiperdex : Madara("Hiperdex", "https://hiperdex.com", "en") {
+class Hiperdex : Madara("Hiperdex", "https://hiperdex.net", "en") {
     override fun getGenreList() = listOf(
         Genre("Adult", "adult"),
         Genre("Action", "action"),


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/2653

Also: 

More Madara sources are using different attributes for thumbnail URLs.  I'd initially intended to fix sources as needed but I changed my mind and think a blanket approach will be better.

Updated Hiperdex's URL.