### PR TITLE
Update language and old manga url at Union Mangás

### DIFF
--- a/src/pt/unionmangas/build.gradle
+++ b/src/pt/unionmangas/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Union Mangás'
     pkgNameSuffix = 'pt.unionmangas'
     extClass = '.UnionMangas'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 

--- a/src/pt/unionmangas/src/eu/kanade/tachiyomi/extension/pt/unionmangas/UnionMangas.kt
+++ b/src/pt/unionmangas/src/eu/kanade/tachiyomi/extension/pt/unionmangas/UnionMangas.kt
@@ -9,21 +9,29 @@ import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
 import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
-import okhttp3.*
+import okhttp3.FormBody
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import java.text.ParseException
 import java.text.SimpleDateFormat
-import java.util.*
+import java.util.Locale
 import java.util.concurrent.TimeUnit
 
 class UnionMangas : ParsedHttpSource() {
+
+    // Hardcode the id because the language wasn't specific.
+    override val id: Long = 6931383302802153355
 
     override val name = "Union Mangás"
 
     override val baseUrl = "https://unionmangas.top"
 
-    override val lang = "pt"
+    override val lang = "pt-BR"
 
     override val supportsLatest = true
 
@@ -38,17 +46,21 @@ class UnionMangas : ParsedHttpSource() {
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
         .add("User-Agent", USER_AGENT)
         .add("Origin", baseUrl)
-        .add("Referer", "$baseUrl/qa")
+        .add("Referer", "$baseUrl/ax")
 
     override fun popularMangaRequest(page: Int): Request {
+        val newHeaders = headersBuilder()
+            .set("Referer", "$baseUrl/lista-mangas" + (if (page == 1) "" else "/visualizacoes/${page - 1}"))
+            .build()
+
         val pageStr = if (page != 1) "/$page" else ""
-        return GET("$baseUrl/lista-mangas/visualizacoes$pageStr", headers)
+        return GET("$baseUrl/lista-mangas/visualizacoes$pageStr", newHeaders)
     }
 
     override fun popularMangaSelector(): String = "div.bloco-manga"
 
     override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
-        title = removeLanguage(element.select("a").last().text())
+        title = element.select("a").last().text().withoutLanguage()
         thumbnail_url = element.select("a img").first()?.attr("src")
         setUrlWithoutDomain(element.select("a").last().attr("href"))
     }
@@ -60,8 +72,10 @@ class UnionMangas : ParsedHttpSource() {
             .add("pagina", page.toString())
             .build()
 
-        val newHeaders = headers.newBuilder()
-            .set("X-Requested-With", "XMLHttpRequest")
+        val newHeaders = headersBuilder()
+            .add("Content-Type", form.contentType().toString())
+            .add("Content-Length", form.contentLength().toString())
+            .add("X-Requested-With", "XMLHttpRequest")
             .build()
 
         return POST("$baseUrl/assets/noticias.php", newHeaders, form)
@@ -72,7 +86,7 @@ class UnionMangas : ParsedHttpSource() {
     override fun latestUpdatesFromElement(element: Element): SManga = SManga.create().apply {
         val infoElement = element.select("a.link-titulo")
 
-        title = removeLanguage(infoElement.last().text())
+        title = infoElement.last().text().withoutLanguage()
         thumbnail_url = infoElement.first()?.select("img")?.attr("src")
         setUrlWithoutDomain(infoElement.last().attr("href"))
     }
@@ -80,8 +94,8 @@ class UnionMangas : ParsedHttpSource() {
     override fun latestUpdatesNextPageSelector() = "div#linha-botao-mais"
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        val newHeaders = headers.newBuilder()
-            .set("X-Requested-With", "XMLHttpRequest")
+        val newHeaders = headersBuilder()
+            .add("X-Requested-With", "XMLHttpRequest")
             .build()
 
         val url = HttpUrl.parse("$baseUrl/assets/busca.php")!!.newBuilder()
@@ -93,7 +107,8 @@ class UnionMangas : ParsedHttpSource() {
     override fun searchMangaParse(response: Response): MangasPage {
         val result = response.asJsonObject()
 
-        val mangas = result["items"].array.map { searchMangaFromObject(it.obj) }
+        val mangas = result["items"].array
+            .map { searchMangaFromObject(it.obj) }
 
         return MangasPage(mangas, false)
     }
@@ -101,10 +116,8 @@ class UnionMangas : ParsedHttpSource() {
     private fun searchMangaFromObject(obj: JsonObject): SManga = SManga.create().apply {
         title = obj["titulo"].string
         thumbnail_url = obj["imagem"].string
-        setUrlWithoutDomain("$baseUrl/manga/${obj["url"].string}")
+        setUrlWithoutDomain("$baseUrl/perfil-manga/${obj["url"].string}")
     }
-
-    override fun mangaDetailsRequest(manga: SManga): Request = GET(baseUrl + manga.url, headers)
 
     override fun mangaDetailsParse(document: Document): SManga {
         val infoElement = document.select("div.tamanho-bloco-perfil").first()
@@ -116,11 +129,12 @@ class UnionMangas : ParsedHttpSource() {
         val imgThumbnail = infoElement.select(".img-thumbnail").first()
         val elTitle = infoElement.select("h2").first()
 
+
         return SManga.create().apply {
-            title = removeLanguage(elTitle!!.text())
-            author = removeLabel(elAuthor?.text())
-            artist = removeLabel(elArtist?.text())
-            genre = removeLabel(elGenre?.text())
+            title = elTitle!!.text().withoutLanguage()
+            author = elAuthor?.textWithoutLabel()
+            artist = elArtist?.textWithoutLabel()
+            genre = elGenre?.textWithoutLabel()
             status = parseStatus(elStatus?.text().orEmpty())
             description = elDescription?.text()
             thumbnail_url = imgThumbnail?.attr("src")
@@ -133,8 +147,6 @@ class UnionMangas : ParsedHttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun chapterListRequest(manga: SManga): Request = GET(baseUrl + manga.url, headers)
-
     override fun chapterListSelector() = "div.row.lancamento-linha"
 
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
@@ -143,21 +155,25 @@ class UnionMangas : ParsedHttpSource() {
 
         name = firstColumn.select("a").first().text()
         scanlator = secondColumn?.text()
-        date_upload = parseChapterDate(firstColumn.select("span").last()!!.text())
+        date_upload = DATE_FORMATTER.tryParseTime(firstColumn.select("span").last()!!.text())
         setUrlWithoutDomain(firstColumn.select("a").first().attr("href"))
     }
 
-    override fun pageListRequest(chapter: SChapter): Request = GET(baseUrl + chapter.url, headers)
-
     override fun pageListParse(document: Document): List<Page> {
-        val pages = document.select("img.img-responsive.img-manga")
-
-        return pages
-            .filter { it.attr("src").contains("leitor") }
-            .mapIndexed { i, element -> Page(i, "", element.absUrl("src"))}
+        return document.select("img.img-responsive.img-manga")
+            .filter { it.attr("src").contains("/leitor/") }
+            .mapIndexed { i, element -> Page(i, document.location(), element.absUrl("src"))}
     }
 
     override fun imageUrlParse(document: Document) = ""
+
+    override fun imageRequest(page: Page): Request {
+        val newHeaders = headersBuilder()
+            .set("Referer", page.url)
+            .build()
+
+        return GET(page.imageUrl!!, newHeaders)
+    }
 
     override fun searchMangaSelector() = throw Exception("This method should not be called!")
 
@@ -165,22 +181,25 @@ class UnionMangas : ParsedHttpSource() {
 
     override fun searchMangaNextPageSelector() = throw Exception("This method should not be called!")
 
-    private fun removeLanguage(text: String): String = text.replace("(Pt-Br)", "", true).trim()
-
-    private fun removeLabel(text: String?): String = text!!.substringAfter(":").trim()
-
-    private fun parseChapterDate(date: String) : Long {
+    private fun SimpleDateFormat.tryParseTime(date: String) : Long {
         return try {
-            SimpleDateFormat("(dd/MM/yyyy)", Locale.ENGLISH).parse(date).time
+            parse(date).time
         } catch (e: ParseException) {
             0L
         }
     }
 
+    private fun String.withoutLanguage(): String = replace("(Pt-Br)", "", true).trim()
+
+    private fun Element.textWithoutLabel(): String = text()!!.substringAfter(":").trim()
+
     private fun Response.asJsonObject(): JsonObject = JSON_PARSER.parse(body()!!.string()).obj
 
     companion object {
         private const val USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.92 Safari/537.36"
+
         private val JSON_PARSER by lazy { JsonParser() }
+
+        private val DATE_FORMATTER by lazy { SimpleDateFormat("(dd/MM/yyyy)", Locale.ENGLISH) }
     }
 }


### PR DESCRIPTION
To those who update: Union Mangás is now under the *Português (Brasil)* category at *Sources*.