### PR TITLE
Fix thumbnails not showing at MangaHost

### DIFF
--- a/src/pt/mangahost/build.gradle
+++ b/src/pt/mangahost/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaHost'
     pkgNameSuffix = 'pt.mangahost'
     extClass = '.MangaHost'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Also fix #2583 by changing the URLs in popular and latest to the same used in the search. 

Unfortunately, users will have to re-add their mangas in the library (or migrate to the same source) to update to the new URL used if they want that their library mangas are marked as added in the listing. The old URL still works though.