### PR TITLE
Mangahere - fix pages

### DIFF
--- a/src/en/mangahere/build.gradle
+++ b/src/en/mangahere/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangahere'
     pkgNameSuffix = 'en.mangahere'
     extClass = '.Mangahere'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/2689

Applies logic that fixed mangahere's webtoons to manga as well.