### PR TITLE
JB page list fix.

### DIFF
--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: FoolSlide (multiple sources)'
     pkgNameSuffix = 'all.foolslide'
     extClass = '.FoolSlideFactory'
-    extVersionCode = 37
+    extVersionCode = 38
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Fixes #2768  

It seems like FoolSlide has a (rather barebones) API available, but it's mostly useful for chapter pages since you'd otherwise have to source an ID for the series. 

Technically, the overrides would work in the main `FoolSlide` class, but there are some edge cases where sites don't properly set their chapter numbers correctly, causing the call to fail. I haven't seen any chapters on JB that suffer from this, so I've kept the API usage localized to that extension.