### PR TITLE
MangaBox - redirect check, selectors

### DIFF
--- a/src/all/mangabox/build.gradle
+++ b/src/all/mangabox/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaBox (Mangakakalot and others)'
     pkgNameSuffix = 'all.mangabox'
     extClass = '.MangaBoxFactory'
-    extVersionCode = 19
+    extVersionCode = 20
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/2840

Also throws an exception message "Source URL has changed" when refreshing manga details or chapter list of a manga that Kakalot's made a new entry for.