### PR TITLE
MangaMx Cloudflare fix

### DIFF
--- a/src/es/mangamx/build.gradle
+++ b/src/es/mangamx/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaMx & Doujin-Yang'
     pkgNameSuffix = 'es.mangamx'
     extClass = '.MangaMx'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 

--- a/src/es/mangamx/src/eu/kanade/tachiyomi/extension/es/mangamx/MangaMx.kt
+++ b/src/es/mangamx/src/eu/kanade/tachiyomi/extension/es/mangamx/MangaMx.kt
@@ -31,6 +31,8 @@ open class MangaMx : ParsedHttpSource() {
     override val baseUrl = "https://manga-mx.com"
     override val lang = "es"
     override val supportsLatest = true
+    override val client = network.cloudflareClient
+
     private var csrfToken = ""
 
     // Popular


### PR DESCRIPTION
Manga-mx.com uses Cloudflare.
Using the Cloudflare client makes it usable again.