### PR TITLE
Mangahub - fix title

### DIFF
--- a/src/en/mangahub/build.gradle
+++ b/src/en/mangahub/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Mangahub'
     pkgNameSuffix = 'en.mangahub'
     extClass = '.Mangahub'
-    extVersionCode = 5
+    extVersionCode = 6
     libVersion = '1.2'
 }
 

--- a/src/en/mangahub/src/eu/kanade/tachiyomi/extension/en/mangahub/Mangahub.kt
+++ b/src/en/mangahub/src/eu/kanade/tachiyomi/extension/en/mangahub/Mangahub.kt
@@ -72,7 +72,7 @@ class Mangahub : ParsedHttpSource() {
 
     override fun mangaDetailsParse(document: Document): SManga {
         val manga = SManga.create()
-        manga.title = document.select("h1._3xnDj").first().text()
+        manga.title = document.select("h1._3xnDj").first().ownText()
         manga.author = document.select("._3QCtP > div:nth-child(2) > div:nth-child(1) > span:nth-child(2)")?.first()?.text()
         manga.artist = document.select("._3QCtP > div:nth-child(2) > div:nth-child(2) > span:nth-child(2)")?.first()?.text()
         manga.genre = document.select("._3Czbn a")?.joinToString { it.text() }


### PR DESCRIPTION
This fixes alternative names and labels like Hot or New being appended to the manga title.