### PR TITLE
Tapas - filter future releases

### DIFF
--- a/src/en/tapastic/build.gradle
+++ b/src/en/tapastic/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Tapas'
     pkgNameSuffix = 'en.tapastic'
     extClass = '.Tapastic'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
 }
 

--- a/src/en/tapastic/build.gradle
+++ b/src/en/tapastic/build.gradle
@@ -12,6 +12,7 @@ ext {
 dependencies {
     compileOnly 'com.google.code.gson:gson:2.8.2'
     compileOnly 'com.github.salomonbrys.kotson:kotson:2.5.0'
+    compileOnly 'com.github.inorichi.injekt:injekt-core:65b0440'
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/en/tapastic/src/eu/kanade/tachiyomi/extension/en/tapastic/Tapastic.kt
+++ b/src/en/tapastic/src/eu/kanade/tachiyomi/extension/en/tapastic/Tapastic.kt
@@ -35,7 +35,7 @@ class Tapastic : ConfigurableSource, ParsedHttpSource() {
         val chapterListPref = androidx.preference.ListPreference(screen.context).apply {
             key = SHOW_LOCKED_CHAPTERS_Title
             title = SHOW_LOCKED_CHAPTERS_Title
-            entries = prefsEntires
+            entries = prefsEntries
             entryValues = prefsEntryValues
             summary = "%s"
 
@@ -53,7 +53,7 @@ class Tapastic : ConfigurableSource, ParsedHttpSource() {
         val chapterListPref = ListPreference(screen.context).apply {
             key = SHOW_LOCKED_CHAPTERS_Title
             title = SHOW_LOCKED_CHAPTERS_Title
-            entries = prefsEntires
+            entries = prefsEntries
             entryValues = prefsEntryValues
             summary = "%s"
 
@@ -72,7 +72,7 @@ class Tapastic : ConfigurableSource, ParsedHttpSource() {
     companion object {
         private const val SHOW_LOCKED_CHAPTERS_Title = "Show or don't show future/locked chapters"
         private const val SHOW_LOCKED_CHAPTERS = "tapas_locked_chapters"
-        private val prefsEntires = arrayOf("Show All", "Show free/currently available")
+        private val prefsEntries = arrayOf("Show All", "Show free/currently available")
         private val prefsEntryValues = arrayOf("all", "free")
     }
 

--- a/src/en/tapastic/src/eu/kanade/tachiyomi/extension/en/tapastic/Tapastic.kt
+++ b/src/en/tapastic/src/eu/kanade/tachiyomi/extension/en/tapastic/Tapastic.kt
@@ -21,8 +21,9 @@ class Tapastic : ParsedHttpSource() {
     // Info
     override val lang = "en"
     override val supportsLatest = true
-    override val name = "Tapastic"
+    override val name = "Tapas" // originally Tapastic
     override val baseUrl = "https://tapas.io"
+    override val id = 3825434541981130345
 
     // Popular
 
@@ -76,12 +77,7 @@ class Tapastic : ParsedHttpSource() {
     override fun searchMangaSelector() = "${popularMangaSelector()}, .search-item-wrap"
     override fun searchMangaFromElement(element: Element): SManga = SManga.create().apply {
         url = element.select(".item__thumb a, .title-section .title a").attr("href")
-        val browseTitle = element.select(".item__thumb img")
-        title = if (browseTitle != null) {
-            browseTitle.attr("alt")
-        } else {
-            element.select(".title-section .title a").text()
-        }
+        title = element.select(".item__thumb img").firstOrNull()?.attr("alt") ?: element.select(".title-section .title a").text()
         thumbnail_url = element.select(".item__thumb img, .thumb-wrap img").attr("src")
     }
 
@@ -117,7 +113,7 @@ class Tapastic : ParsedHttpSource() {
         return chapters
     }
 
-    override fun chapterListSelector() = "li.content__item"
+    override fun chapterListSelector() = "li.content__item:not(:has(.info__tag):contains(release date))" // filter future releases
     override fun chapterFromElement(element: Element): SChapter = SChapter.create().apply {
         val lock = !element.select(".sp-ico-episode-lock, .sp-ico-schedule-white").isNullOrEmpty()
         name = if (lock) {


### PR DESCRIPTION
Users can change their configuration to show all chapters or only the ones that are free and currently available (not slated to release at a future date).

Closes https://github.com/inorichi/tachiyomi-extensions/issues/3080
Closes https://github.com/inorichi/tachiyomi-extensions/issues/1165