### PR TITLE
Change Hiperdex url

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 90
+    extVersionCode = 91
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -291,7 +291,7 @@ class Milftoon : Madara("Milftoon", "https://milftoon.xxx", "en") {
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/page/$page/?m_orderby=latest", headers)
 }
 
-class Hiperdex : Madara("Hiperdex", "https://hiperdex.com", "en") {
+class Hiperdex : Madara("Hiperdex", "https://hiperdex.info", "en") {
     override fun getGenreList() = listOf(
         Genre("Adult", "adult"),
         Genre("Action", "action"),


### PR DESCRIPTION
It would seem that Hiperdex has changed from Hiperdex.com to Hiperdex.info (which has made the source unusable.

Fixes #3100