### PR TITLE
Tapas - refactor chapter list

### DIFF
--- a/src/en/tapastic/build.gradle
+++ b/src/en/tapastic/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Tapas'
     pkgNameSuffix = 'en.tapastic'
     extClass = '.Tapastic'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
To be honest, I can't be 100% sure this works. The URLs are being set now for paid chapters; so if a user logs in, has paid for the chapters, and sets the extension's preferences, in theory they may be able to read those locked chapters.  I'm not paying for chapters to verify though.

Closes https://github.com/inorichi/tachiyomi-extensions/issues/3197