### PR TITLE
Refactor the HiperCool extension

### DIFF
--- a/src/pt/hipercool/build.gradle
+++ b/src/pt/hipercool/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: HipercooL'
     pkgNameSuffix = 'pt.hipercool'
     extClass = '.Hipercool'
-    extVersionCode = 3
+    extVersionCode = 4
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
The PR #3191 will cause an error with the removal of two `.toString()` calls in Hipercool, so I decided to refactor the extension and use proper methods to take some data from the chapter URL instead of using RegEx.