### PR TITLE
[Mangadex] Add Data saver option to ext preferences

### DIFF
--- a/src/all/mangadex/build.gradle
+++ b/src/all/mangadex/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: MangaDex'
     pkgNameSuffix = 'all.mangadex'
     extClass = '.MangadexFactory'
-    extVersionCode = 90
+    extVersionCode = 91
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Verified that the 'server' value that gets returned with 'saver=1' is `mangadex.org/data-saver/` and that it remains the default `mangadex.org/data/` with 'saver=0'