### PR TITLE
Change BaixarHentai URL to the old one

### DIFF
--- a/src/all/foolslide/build.gradle
+++ b/src/all/foolslide/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: FoolSlide (multiple sources)'
     pkgNameSuffix = 'all.foolslide'
     extClass = '.FoolSlideFactory'
-    extVersionCode = 49
+    extVersionCode = 50
     libVersion = '1.2'
 }
 

--- a/src/all/foolslide/src/eu/kanade/tachiyomi/extension/all/foolslide/FoolSlideFactory.kt
+++ b/src/all/foolslide/src/eu/kanade/tachiyomi/extension/all/foolslide/FoolSlideFactory.kt
@@ -161,7 +161,7 @@ class KirishimaFansub : FoolSlide("Kirishima Fansub", "https://www.kirishimafans
 
 class PowerMangaIT : FoolSlide("PowerManga", "https://reader.powermanga.org", "it", "")
 
-class BaixarHentai : FoolSlide("Baixar Hentai", "https://baixarhentai.net", "pt-BR", "/listona") {
+class BaixarHentai : FoolSlide("Baixar Hentai", "https://leitura.baixarhentai.net", "pt-BR") {
     // Hardcode the id because the language wasn't specific.
     override val id: Long = 8908032188831949972
 


### PR DESCRIPTION
Closes #3373.

The PR #3230 changed the source URL to a wrong one that isn't a Foolslide instance.