### PR TITLE
Minor fixes for MangaPlus extension

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -6,7 +6,7 @@ ext {
     appName = 'Tachiyomi: MANGA Plus by SHUEISHA'
     pkgNameSuffix = 'all.mangaplus'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 8
+    extVersionCode = 9
     libVersion = '1.2'
 }
 

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -35,15 +35,11 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 abstract class MangaPlus(
+    override val id: Long,
     override val lang: String,
     private val internalLang: String,
     private val langCode: Language
 ) : HttpSource(), ConfigurableSource {
-
-    // Hardcode the id because the old name wasn't matching the official service name.
-    override val id: Long by lazy {
-        if (lang == "en") OLD_ENGLISH_ID else OLD_SPANISH_ID
-    }
 
     override val name = "MANGA Plus by SHUEISHA"
 
@@ -453,8 +449,5 @@ abstract class MangaPlus(
         private const val SPLIT_PREF_DEFAULT_VALUE = true
 
         private val COMPLETE_REGEX = "completado|complete".toRegex()
-
-        private const val OLD_ENGLISH_ID: Long = 1998944621602463790
-        private const val OLD_SPANISH_ID: Long = 1286073245950890830
     }
 }

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -35,7 +35,6 @@ import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
 
 abstract class MangaPlus(
-    override val id: Long,
     override val lang: String,
     private val internalLang: String,
     private val langCode: Language

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlus.kt
@@ -40,7 +40,12 @@ abstract class MangaPlus(
     private val langCode: Language
 ) : HttpSource(), ConfigurableSource {
 
-    override val name = "Manga Plus by Shueisha"
+    // Hardcode the id because the old name wasn't matching the official service name.
+    override val id: Long by lazy {
+        if (lang == "en") OLD_ENGLISH_ID else OLD_SPANISH_ID
+    }
+
+    override val name = "MANGA Plus by SHUEISHA"
 
     override val baseUrl = "https://mangaplus.shueisha.co.jp"
 
@@ -196,8 +201,8 @@ abstract class MangaPlus(
         val isCompleted = details.nonAppearanceInfo.contains(COMPLETE_REGEX)
 
         return SManga.create().apply {
-            author = title.author
-            artist = title.author
+            author = title.author.replace(" / ", ", ")
+            artist = author
             description = details.overview + "\n\n" + details.viewingPeriodDescription
             status = if (isCompleted) SManga.COMPLETED else SManga.ONGOING
             thumbnail_url = title.portraitImageUrl.toWeservUrl()
@@ -448,5 +453,8 @@ abstract class MangaPlus(
         private const val SPLIT_PREF_DEFAULT_VALUE = true
 
         private val COMPLETE_REGEX = "completado|complete".toRegex()
+
+        private const val OLD_ENGLISH_ID: Long = 1998944621602463790
+        private const val OLD_SPANISH_ID: Long = 1286073245950890830
     }
 }

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusApi.kt
@@ -76,7 +76,7 @@ data class Title(
     @ProtoId(3) val author: String,
     @ProtoId(4) val portraitImageUrl: String,
     @ProtoId(5) val landscapeImageUrl: String,
-    @ProtoId(6) val viewCount: Int,
+    @ProtoId(6) val viewCount: Int = 0,
     @ProtoId(7) val language: Language? = Language.ENGLISH
 )
 
@@ -189,6 +189,7 @@ const val DECODE_SCRIPT: String = """
         .add(new Field("nextTimeStamp", 5, "uint32"))
         .add(new Field("updateTiming", 6, "UpdateTiming"))
         .add(new Field("viewingPeriodDescription", 7, "string"))
+        .add(new Field("nonAppearanceInfo", 8, "string", {"default": ""}))
         .add(new Field("firstChapterList", 9, "Chapter", "repeated"))
         .add(new Field("lastChapterList", 10, "Chapter", "repeated"))
         .add(new Field("isSimulReleased", 14, "bool"))
@@ -214,7 +215,7 @@ const val DECODE_SCRIPT: String = """
         .add(new Field("author", 3, "string"))
         .add(new Field("portraitImageUrl", 4, "string"))
         .add(new Field("landscapeImageUrl", 5, "string"))
-        .add(new Field("viewCount", 6, "uint32"))
+        .add(new Field("viewCount", 6, "uint32", {"default": 0}))
         .add(new Field("language", 7, "Language", {"default": 0}));
 
     var Language = new Enum("Language")

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
@@ -7,8 +7,9 @@ class MangaPlusFactory : SourceFactory {
     override fun createSources(): List<Source> = getAllMangaPlus()
 }
 
-class MangaPlusEnglish : MangaPlus("en", "eng", Language.ENGLISH)
-class MangaPlusSpanish : MangaPlus("es", "esp", Language.SPANISH)
+// The ids are hardcoded because the old name wasn't matching the official service name.
+class MangaPlusEnglish : MangaPlus(1998944621602463790, "en", "eng", Language.ENGLISH)
+class MangaPlusSpanish : MangaPlus(1286073245950890830, "es", "esp", Language.SPANISH)
 
 fun getAllMangaPlus(): List<Source> = listOf(
     MangaPlusEnglish(),

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
@@ -8,8 +8,8 @@ class MangaPlusFactory : SourceFactory {
 }
 
 // The ids are hardcoded because the old name wasn't matching the official service name.
-class MangaPlusEnglish : MangaPlus(1998944621602463790, "en", "eng", Language.ENGLISH)
-class MangaPlusSpanish : MangaPlus(1286073245950890830, "es", "esp", Language.SPANISH)
+class MangaPlusEnglish : MangaPlus("en", "eng", Language.ENGLISH)
+class MangaPlusSpanish : MangaPlus("es", "esp", Language.SPANISH)
 
 fun getAllMangaPlus(): List<Source> = listOf(
     MangaPlusEnglish(),

--- a/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
+++ b/src/all/mangaplus/src/eu/kanade/tachiyomi/extension/all/mangaplus/MangaPlusFactory.kt
@@ -7,7 +7,6 @@ class MangaPlusFactory : SourceFactory {
     override fun createSources(): List<Source> = getAllMangaPlus()
 }
 
-// The ids are hardcoded because the old name wasn't matching the official service name.
 class MangaPlusEnglish : MangaPlus("en", "eng", Language.ENGLISH)
 class MangaPlusSpanish : MangaPlus("es", "esp", Language.SPANISH)
 


### PR DESCRIPTION
- Possible fix to missing `viewCount` field error, now it has a default value;
- Change the source name to match the official service name, overriding the `id`;
- Change the way that authors are displayed to match the latest UI change in the preview version;
- Add missing `nonAppearanceInfo` field to Duktape parsing.