### PR TITLE
MangaMutiny - JsonNull fix

### DIFF
--- a/src/en/mangamutiny/build.gradle
+++ b/src/en/mangamutiny/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: Manga Mutiny'
     pkgNameSuffix = "en.mangamutiny"
     extClass = '.MangaMutiny'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
+++ b/src/en/mangamutiny/src/eu/kanade/tachiyomi/extension/en/mangamutiny/MangaMutiny.kt
@@ -140,8 +140,8 @@ class MangaMutiny : HttpSource() {
                     "completed" -> SManga.COMPLETED
                     else -> SManga.UNKNOWN
                 }
-                description = rootNode.get("summary").asString
-                thumbnail_url = rootNode.get("thumbnail")?.asString
+                description = rootNode.getNullable("summary")?.asString
+                thumbnail_url = rootNode.getNullable("thumbnail")?.asString
                 title = rootNode.get("title").asString
                 url = rootNode.get("slug").asString
                 artist = rootNode.get("artists").asString
@@ -211,7 +211,7 @@ class MangaMutiny : HttpSource() {
                     val mangaObject = singleItem.asJsonObject
                     mangasPage.add(SManga.create().apply {
                         this.title = mangaObject.get("title").asString
-                        this.thumbnail_url = mangaObject.get("thumbnail")?.asString
+                        this.thumbnail_url = mangaObject.getNullable("thumbnail")?.asString
                         this.url = mangaObject.get("slug").asString
                     })
                 }


### PR DESCRIPTION
Some thumbnails and manga descriptions aren't maintained by the website.
This results in avoidable errors. Fixed with this commit.