### PR TITLE
Fix Viz thumbnails

### DIFF
--- a/src/en/vizshonenjump/build.gradle
+++ b/src/en/vizshonenjump/build.gradle
@@ -5,7 +5,7 @@ ext {
     appName = 'Tachiyomi: VIZ Shonen Jump'
     pkgNameSuffix = 'en.vizshonenjump'
     extClass = '.VizShonenJump'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/VizShonenJump.kt
+++ b/src/en/vizshonenjump/src/eu/kanade/tachiyomi/extension/en/vizshonenjump/VizShonenJump.kt
@@ -61,7 +61,7 @@ class VizShonenJump : ParsedHttpSource() {
 
     override fun popularMangaFromElement(element: Element): SManga = SManga.create().apply {
         title = element.select("div.pad-x-rg").first().text()
-        thumbnail_url = element.select("div.pos-r img.disp-bl").first()?.attr("src")
+        thumbnail_url = element.select("div.pos-r img.disp-bl").first()?.attr("data-original")
         url = element.attr("href")
     }
 


### PR DESCRIPTION
Previously the Viz thumbnails were getting set to a placeholder image in the static HTML rather than the actual thumbnail image that was placed once the page loaded through javascript. This has been fixed.

Resolves #3567.