### PR TITLE
MRM - Update Page Selector

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 34
+    extVersionCode = 35
     libVersion = '1.2'
 }
 

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -204,7 +204,7 @@ open class MyReadingManga(override val lang: String, private val siteLang: Strin
     override fun pageListParse(response: Response): List<Page> {
         val body = response.asJsoup()
         val pages = mutableListOf<Page>()
-        val elements = body.select("img[data-lazy-src]:not([width='120']):not([data-original-width='300'])")
+        val elements = body.select("div>img")
         for (i in 0 until elements.size) {
             pages.add(Page(i, "", getImage(elements[i])))
         }


### PR DESCRIPTION
Fixes page selector for My Reading Manga

--

My Reading Manga stopped working and it seems like they have stopped using the lazy loader extension. I think this happened before in the history of the site so I'm not sure if they are just updating the plugin or not. 

This is a quick page update to account for the current change so I'm not sure if you want to merge this yet. 
If you do, we can update it if and when the owners load a lazy loader plugin back onto the server. 