### PR TITLE
MyReadingManga - some refactoring, added language filter

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 35
+    extVersionCode = 36
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3707
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3250
Closes https://github.com/inorichi/tachiyomi-extensions/issues/2997

There's now a filter checkbox titled "Enforce language" set to true by default. While true, search results are from a single language; while false (unchecked) all languages will show up in results.

Regarding incorrect scanlator groups: it's actually too troublesome to correct for too little gain. I've removed it from chapter info and made it it part of the manga description instead.

Covers should work better on refresh/import.