### PR TITLE
Madara - update sources, annex Manhua Plus from WP Comics

### DIFF
--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Madara (multiple sources)'
     pkgNameSuffix = "all.madara"
     extClass = '.MadaraFactory'
-    extVersionCode = 116
+    extVersionCode = 117
     libVersion = '1.2'
 }
 

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/Madara.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/Madara.kt
@@ -44,8 +44,11 @@ abstract class Madara(
         .readTimeout(30, TimeUnit.SECONDS)
         .build()
 
+    // helps with cloudflare for some sources, makes it worse for others; override with empty string if the latter is true
+    protected open val userAgentRandomizer = " ${Random.nextInt().absoluteValue}"
+
     override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0 ${Random.nextInt().absoluteValue}")
+        .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/78.0$userAgentRandomizer")
 
     // Popular Manga
 
@@ -415,7 +418,7 @@ abstract class Madara(
 
         fun SimpleDateFormat.tryParse(string: String): Long {
             return try {
-                parse(string).time
+                parse(string)?.time ?: 0
             } catch (_: ParseException) {
                 0
             }

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -95,7 +95,6 @@ class MadaraFactory : SourceFactory {
         NinjaScans(),
         NovelFrance(),
         OnManga(),
-        PlotTwistScan(),
         PMScans(),
         PojokManga(),
         PornComix(),
@@ -152,7 +151,10 @@ class MadaraFactory : SourceFactory {
         FurioScans(),
         Mangareceh(),
         KlanKomik(),
-        ComicKiba()
+        ComicKiba(),
+        ToonPoint(),
+        MangaScantrad(),
+        ManhuaPlus()
         // Removed by request of site owner
         // EarlyManga(),
         // MangaGecesi(),
@@ -299,8 +301,7 @@ class Manga3asq : Madara("مانجا العاشق", "https://3asq.org", "ar")
 class Indiancomicsonline : Madara("Indian Comics Online", "http://www.indiancomicsonline.com", "hi")
 
 class AdonisFansub : Madara("Adonis Fansub", "https://manga.adonisfansub.com", "tr") {
-    override fun headersBuilder(): Headers.Builder = Headers.Builder()
-        .add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:77.0) Gecko/20100101 Firefox/77.0")
+    override val userAgentRandomizer = ""
     override fun popularMangaRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=views", headers)
     override fun latestUpdatesRequest(page: Int): Request = GET("$baseUrl/manga/page/$page/?m_orderby=latest", headers)
 }
@@ -669,10 +670,6 @@ class Toonily : Madara("Toonily", "https://toonily.com", "en") {
     )
 }
 
-class PlotTwistScan : Madara("Plot Twist No Fansub", "https://www.plotwistscan.com", "es") {
-    override fun chapterListParse(response: Response): List<SChapter> = super.chapterListParse(response).asReversed()
-}
-
 class MangaKomi : Madara("MangaKomi", "https://mangakomi.com", "en", SimpleDateFormat("MM/dd/yyyy", Locale.US))
 
 class Wakamics : Madara("Wakamics", "https://wakamics.com", "en")
@@ -851,13 +848,6 @@ class UnknownScans : Madara("Unknown Scans", "https://unknoscans.com", "en")
 
 class Manga68 : Madara("Manga68", "https://manga68.com", "en") {
     override val pageListParseSelector = "div.page-break, div.text-left p"
-    override fun pageListParse(document: Document): List<Page> {
-        return document.select(pageListParseSelector).mapIndexed { index, element ->
-            Page(index, "", element.select("img").first()?.let {
-                it.absUrl(/*if (it.hasAttr("data-lazy-src")) "data-lazy-src" else */if (it.hasAttr("data-src")) "data-src" else "src")
-            })
-        }.filter { it.imageUrl!!.startsWith("http") }
-    }
 }
 
 class ManhuaBox : Madara("ManhuaBox", "https://manhuabox.net", "en") {
@@ -1191,3 +1181,13 @@ class ComicKiba : Madara("ComicKiba", "https://comickiba.com", "en") {
 }
 
 class KlanKomik : Madara("KlanKomik", "https://klankomik.com", "id")
+
+class ToonPoint : Madara("ToonPoint", "https://toonpoint.com", "en") {
+    override val userAgentRandomizer = ""
+}
+
+class MangaScantrad : Madara("Manga-Scantrad", "https://manga-scantrad.net", "fr", SimpleDateFormat("d MMM yyyy", Locale.FRANCE))
+
+class ManhuaPlus : Madara("Manhua Plus", "https://manhuaplus.com", "en") {
+    override val pageListParseSelector = "li.blocks-gallery-item"
+}

--- a/src/all/wpcomics/build.gradle
+++ b/src/all/wpcomics/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'WP-Comics'
     pkgNameSuffix = 'all.wpcomics'
     extClass = '.WPComicsFactory'
-    extVersionCode = 9
+    extVersionCode = 10
     libVersion = '1.2'
 }
 

--- a/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
+++ b/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
@@ -19,7 +19,6 @@ import org.jsoup.nodes.Element
 @MultiSource
 class WPComicsFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
-        ManhuaPlus(),
         ManhuaES(),
         MangaSum(),
         XoxoComics(),
@@ -27,10 +26,6 @@ class WPComicsFactory : SourceFactory {
         NetTruyen(),
         TruyenChon()
     )
-}
-
-private class ManhuaPlus : WPComics("Manhua Plus", "https://manhuaplus.com", "en") {
-    override val pageListSelector: String = "div.chapter-detail img, ${super.pageListSelector}"
 }
 
 private class ManhuaES : WPComics("Manhua ES", "https://manhuaes.com", "en", SimpleDateFormat("HH:mm - dd/MM/yyyy Z", Locale.US), "+0700") {


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3769
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3761
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3743
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3716
References https://github.com/inorichi/tachiyomi-extensions/issues/3759

* Adds ToonPoint and Manga-Scantrad
* Moves Manhua Plus from WP Comics to Madara
* Fixes Manga68
* Removes Plot Twist No Fansub (their old site doesn't work and the new one doesn't use Madara)