### PR TITLE
EHentai - add language preference

### DIFF
--- a/src/all/ehentai/build.gradle
+++ b/src/all/ehentai/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'E-Hentai'
     pkgNameSuffix = 'all.ehentai'
     extClass = '.EHFactory'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Closes https://github.com/inorichi/tachiyomi-extensions/issues/3802

Strict language enforcement is optional now, by default it's off. So while it's off, browse and search results should be what they were a version or two ago. It can be toggled in preferences if you want it always on/off or can be used as a filter in search if you want to change it for one-off searches\.

"Misc" tags are a more complete list now. Some tags may be ExHentai only, didn't bother filtering them out.