### PR TITLE
Comicpunch - fix chapters and pages not loading

### DIFF
--- a/src/en/comicpunch/build.gradle
+++ b/src/en/comicpunch/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Comicpunch'
     pkgNameSuffix = 'en.comicpunch'
     extClass = '.Comicpunch'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
+++ b/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
@@ -150,7 +150,7 @@ class Comicpunch : ParsedHttpSource() {
         // Then we just split it.
         val pageUrls = document.select("div#code_contain > script")
             .eq(1).first().data()
-            .substringAfter("= [").substringBefore("]").split("'")
+            .substringAfter("messages = [").substringBefore("]").split("'")
 
         pageUrls.forEachIndexed { i, img ->
             pages.add(Page(i, "", URLEncoder.encode(img.toString(), "UTF-8")))

--- a/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
+++ b/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
@@ -117,7 +117,7 @@ class Comicpunch : ParsedHttpSource() {
         var elements = response.asJsoup().select(chapterListSelector()).toList()
 
         // Check if latest chapter is just a placeholder, drop it if it is
-        client.newCall(GET(elements[0].attr("abs:href"), headers)).execute().asJsoup().select("img.picture").attr("src").let { img ->
+        client.newCall(GET(elements[0].attr("abs:href"), headers)).execute().asJsoup().select("img").last().attr("src").let { img ->
             if (img.contains("placeholder", ignoreCase = true)) elements = elements.drop(1)
         }
         elements.map { chapters.add(chapterFromElement(it)) }

--- a/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
+++ b/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.en.comicpunch
 
+import android.util.Log
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -9,7 +10,6 @@ import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import java.net.URLEncoder
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -145,15 +145,11 @@ class Comicpunch : ParsedHttpSource() {
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()
 
-        // Comicpunch appears to store the array of images for each chapter as a variable "messages"
-        // in a script tag. It's the second line and the first and only array, hence we do "= [".
-        // Then we just split it.
         val pageUrls = document.select("div#code_contain > script")
             .eq(1).first().data()
-            .substringAfter("messages = [").substringBefore("]").split("'")
-
+            .substringAfter("= [").substringBefore("]").split(",")
         pageUrls.forEachIndexed { i, img ->
-            pages.add(Page(i, "", URLEncoder.encode(img.toString(), "UTF-8")))
+            pages.add(Page(i, "", img.removeSurrounding("\"")))
         }
 
         return pages

--- a/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
+++ b/src/en/comicpunch/src/eu/kanade/tachiyomi/extension/en/comicpunch/Comicpunch.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.en.comicpunch
 
-import android.util.Log
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.model.FilterList
@@ -137,10 +136,6 @@ class Comicpunch : ParsedHttpSource() {
     }
 
     // Pages
-
-    override fun pageListRequest(chapter: SChapter): Request {
-        return GET(baseUrl + chapter.url, headers)
-    }
 
     override fun pageListParse(document: Document): List<Page> {
         val pages = mutableListOf<Page>()


### PR DESCRIPTION
Comicpunch removed the "div#chapterlist" element from their pages, and didn't have a consistent replacement looking across a few comics, so I just took it out in favor of just using li.chapter.

For pages, they are now stored as an array of urls within a script tag instead of being all loaded by default like before.