### PR TITLE
Comic latest

### DIFF
--- a/src/all/wpcomics/build.gradle
+++ b/src/all/wpcomics/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'WP-Comics'
     pkgNameSuffix = 'all.wpcomics'
     extClass = '.WPComicsFactory'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 

--- a/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
+++ b/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
@@ -8,7 +8,6 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.util.asJsoup
 import java.text.SimpleDateFormat
 import java.util.Locale

--- a/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
+++ b/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
@@ -131,7 +131,7 @@ private class ComicLatest : WPComics("ComicLatest", "https://comiclatest.com", "
 
     override fun searchMangaSelector() = "div.item div.box_img > a[title]"
 
-    //For whatever reason, errors with author search
+    //For whatever reason, errors with author search if this isn't overridden
     override fun searchMangaFromElement(element: Element): SManga {
         return SManga.create().apply {
             title = element.attr("title")

--- a/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
+++ b/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
@@ -4,11 +4,11 @@ import eu.kanade.tachiyomi.annotations.MultiSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
+import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
-import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.util.asJsoup
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -122,17 +122,21 @@ private class ComicLatest : WPComics("ComicLatest", "https://comiclatest.com", "
     }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
-        if (query.startsWith("author:")) {
-            val author = query.substringAfter("author:").trim().replace(" ", "-").toLowerCase()
-            return GET("$baseUrl/author/$author", headers)
-        } else {
-            return GET("$baseUrl/search?keyword=$query", headers)
+        filters.forEach { filter ->
+            when (filter) {
+                is AuthorFilter -> {
+                    val author = filter.state.trim().replace(" ", "-").toLowerCase()
+                    return GET("$baseUrl/author/$author", headers)
+                }
+            }
         }
+
+        return GET("$baseUrl/search?keyword=$query", headers)
     }
 
     override fun searchMangaSelector() = "div.item div.box_img > a[title]"
 
-    //For whatever reason, errors with author search
+    //For whatever reason, errors with author search if this isn't overridden
     override fun searchMangaFromElement(element: Element): SManga {
         return SManga.create().apply {
             title = element.attr("title")
@@ -155,4 +159,12 @@ private class ComicLatest : WPComics("ComicLatest", "https://comiclatest.com", "
     }
 
     override fun pageListRequest(chapter: SChapter) = GET("$baseUrl${chapter.url}/all", headers)
+
+    private class AuthorFilter: Filter.Text("Author")
+
+    override fun getFilterList() = FilterList(
+        Filter.Header("NOTE: Cannot be used with search"),
+        Filter.Separator(),
+        AuthorFilter()
+    )
 }

--- a/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
+++ b/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
@@ -1,5 +1,6 @@
 package eu.kanade.tachiyomi.extension.all.wpcomics
 
+import eu.kanade.tachiyomi.annotations.MultiSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
@@ -16,6 +17,7 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
+@MultiSource
 class WPComicsFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
         ManhuaES(),

--- a/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
+++ b/src/all/wpcomics/src/eu/kanade/tachiyomi/extension/all/wpcomics/WPComicsFactory.kt
@@ -1,6 +1,5 @@
 package eu.kanade.tachiyomi.extension.all.wpcomics
 
-import eu.kanade.tachiyomi.annotations.MultiSource
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
@@ -8,6 +7,7 @@ import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
 import eu.kanade.tachiyomi.source.model.SChapter
 import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.MangasPage
 import eu.kanade.tachiyomi.util.asJsoup
 import java.text.SimpleDateFormat
 import java.util.Locale
@@ -16,7 +16,6 @@ import okhttp3.Response
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 
-@MultiSource
 class WPComicsFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
         ManhuaES(),
@@ -131,7 +130,7 @@ private class ComicLatest : WPComics("ComicLatest", "https://comiclatest.com", "
 
     override fun searchMangaSelector() = "div.item div.box_img > a[title]"
 
-    //For whatever reason, errors with author search if this isn't overridden
+    //For whatever reason, errors with author search
     override fun searchMangaFromElement(element: Element): SManga {
         return SManga.create().apply {
             title = element.attr("title")


### PR DESCRIPTION
Fixes the search on ComicLatest as per https://github.com/inorichi/tachiyomi-extensions/pull/3790#issuecomment-660398990. Also, added the ability to search by author via a text filter. 

NOTE: author search must match the author's name exactly (case-insensitive). 