### PR TITLE
Fix unacessible chapters showing when the manga is licensed at LeitorNet

### DIFF
--- a/src/pt/mangasproject/build.gradle
+++ b/src/pt/mangasproject/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'mangásPROJECT'
     pkgNameSuffix = 'pt.mangasproject'
     extClass = '.MangasProjectFactory'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
The check if the manga is licensed prevents the chapter list API from being called when it's not supposed, simulating the behavior of the website.