### PR TITLE
Fix broken thumbnails after expiration time at MangaPlus

### DIFF
--- a/src/all/mangaplus/build.gradle
+++ b/src/all/mangaplus/build.gradle
@@ -6,7 +6,7 @@ ext {
     extName = 'MANGA Plus by SHUEISHA'
     pkgNameSuffix = 'all.mangaplus'
     extClass = '.MangaPlusFactory'
-    extVersionCode = 10
+    extVersionCode = 11
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Now the extension saves all the titles from the response in an internal list. 

With an additional interceptor, if the requested thumbnail is expired (returned `401` or `404`) it uses the saved title list (that contains all the titles from the service) to find and return the newer thumbnail URL with the most updated `key`, making the thumbnail load properly (at browse, latest, and search).

I tested on my physical device where all the mangas outside my library did have broken thumbnails, and all of them loaded and appeared again. :)

I also removed the Weserv usage.