### PR TITLE
Multiple MangaMutiny fixes/additions

### DIFF
--- a/src/en/mangamutiny/build.gradle
+++ b/src/en/mangamutiny/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Manga Mutiny'
     pkgNameSuffix = "en.mangamutiny"
     extClass = '.MangaMutiny'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
- fixed Genre parsing (website renamed "genres" to "tags" in their json responses)
- corrected chapter release year parsing
- increased manga list fetch size from 20 to 21 to make requests that are almost indistinguishable from requests the real website makes (only URI parameter order differs)
- split Genre filter into Genre and Format filter to be more in line with what the website offers
- updated Genre/Format filter content
- implemented new way to process URI query parameters (first collect them in a mutable list, then add them to the URI)
- added author/artist search (and prepared for scanlator search, although that feature doesn't work yet even on the website)