### PR TITLE
<Manhuagui> Add ratelimit permits preferences and intent filter

### DIFF
--- a/src/zh/manhuagui/AndroidManifest.xml
+++ b/src/zh/manhuagui/AndroidManifest.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application>
+        <activity
+            android:name=".ManhuaguiUrlActivity"
+            android:excludeFromRecents="true"
+            android:theme="@android:style/Theme.NoDisplay">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data
+                    android:host="manhuagui.com"
+                    android:pathPattern="/comic/..*"
+                    android:scheme="https" />
+                <data
+                    android:host="m.manhuagui.com"
+                    android:pathPattern="/comic/..*"
+                    android:scheme="https" />
+                <data
+                    android:host="www.manhuagui.com"
+                    android:pathPattern="/comic/..*"
+                    android:scheme="https" />
+                <data
+                    android:host="tw.manhuagui.com"
+                    android:pathPattern="/comic/..*"
+                    android:scheme="https" />
+            </intent-filter>
+        </activity>
+    </application>
+</manifest>

--- a/src/zh/manhuagui/build.gradle
+++ b/src/zh/manhuagui/build.gradle
@@ -5,12 +5,11 @@ ext {
     extName = 'ManHuaGui'
     pkgNameSuffix = 'zh.manhuagui'
     extClass = '.Manhuagui'
-    extVersionCode = 4
+    extVersionCode = 5
     libVersion = '1.2'
 }
 
 dependencies {
-    implementation project(':lib-ratelimit')
     compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version"
     compileOnly "org.jetbrains.kotlinx:kotlinx-coroutines-android:$coroutines_version"
 }

--- a/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/ManhuaguiRateLimitInterceptor.kt
+++ b/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/ManhuaguiRateLimitInterceptor.kt
@@ -1,0 +1,91 @@
+package eu.kanade.tachiyomi.extension.zh.manhuagui
+
+import android.os.SystemClock
+import java.util.concurrent.TimeUnit
+import okhttp3.Interceptor
+import okhttp3.Response
+
+/**
+ * An OkHttp interceptor modified for Manhuagui extension that handles rate limiting.
+ *
+ * Examples:
+ *
+ * permits = 5,  period = 1, unit = seconds  =>  5 requests per second
+ * permits = 10, period = 2, unit = minutes  =>  10 requests per 2 minutes
+ *
+ * @param baseHost {String}   Manhuagui main website URL host, this URL is not protected by CDN, so it has a more aggressive concurrency request limit.
+ * @param mainSitePermits {Int}   Number of requests allowed within a period of units to main URL.
+ * @param imgCDNPermits {Int}   Number of requests allowed within a period of units to image CDN.
+ * @param period {Long}   The limiting duration. Defaults to 1.
+ * @param unit {TimeUnit} The unit of time for the period. Defaults to seconds.
+ */
+class ManhuaguiRateLimitInterceptor(
+    private val baseHost: String,
+    private val mainSitePermits: Int = 2,
+    private val imgCDNPermits: Int = 5,
+    private val period: Long = 1,
+    private val unit: TimeUnit = TimeUnit.SECONDS
+) : Interceptor {
+
+    private val mainSiteRequestQueue = ArrayList<Long>(mainSitePermits)
+    private val imgCDNRequestQueue = ArrayList<Long>(imgCDNPermits)
+    private val rateLimitMillis = unit.toMillis(period)
+
+    override fun intercept(chain: Interceptor.Chain): Response {
+        if (chain.request().url().host() == baseHost) {
+            synchronized(mainSiteRequestQueue) {
+                val now = SystemClock.elapsedRealtime()
+                val waitTime = if (mainSiteRequestQueue.size < mainSitePermits) {
+                    0
+                } else {
+                    val oldestReq = mainSiteRequestQueue[0]
+                    val newestReq = mainSiteRequestQueue[mainSitePermits - 1]
+
+                    if (newestReq - oldestReq > rateLimitMillis) {
+                        0
+                    } else {
+                        oldestReq + rateLimitMillis - now // Remaining time
+                    }
+                }
+
+                if (mainSiteRequestQueue.size == mainSitePermits) {
+                    mainSiteRequestQueue.removeAt(0)
+                }
+                if (waitTime > 0) {
+                    mainSiteRequestQueue.add(now + waitTime)
+                    Thread.sleep(waitTime) // Sleep inside synchronized to pause queued requests
+                } else {
+                    mainSiteRequestQueue.add(now)
+                }
+            }
+        } else {
+            synchronized(imgCDNRequestQueue) {
+                val now = SystemClock.elapsedRealtime()
+                val waitTime = if (imgCDNRequestQueue.size < imgCDNPermits) {
+                    0
+                } else {
+                    val oldestReq = imgCDNRequestQueue[0]
+                    val newestReq = imgCDNRequestQueue[imgCDNPermits - 1]
+
+                    if (newestReq - oldestReq > rateLimitMillis) {
+                        0
+                    } else {
+                        oldestReq + rateLimitMillis - now // Remaining time
+                    }
+                }
+
+                if (imgCDNRequestQueue.size == imgCDNPermits) {
+                    imgCDNRequestQueue.removeAt(0)
+                }
+                if (waitTime > 0) {
+                    imgCDNRequestQueue.add(now + waitTime)
+                    Thread.sleep(waitTime) // Sleep inside synchronized to pause queued requests
+                } else {
+                    imgCDNRequestQueue.add(now)
+                }
+            }
+        }
+
+        return chain.proceed(chain.request())
+    }
+}

--- a/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/ManhuaguiUrlActivity.kt
+++ b/src/zh/manhuagui/src/eu/kanade/tachiyomi/extension/zh/manhuagui/ManhuaguiUrlActivity.kt
@@ -1,0 +1,41 @@
+package eu.kanade.tachiyomi.extension.zh.manhuagui
+
+import android.app.Activity
+import android.content.ActivityNotFoundException
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import kotlin.system.exitProcess
+
+/**
+ * Springboard that accepts https://www.manhuagui.com/comic/xxx intents and redirects them to
+ * the main tachiyomi process. The idea is to not install the intent filter unless
+ * you have this extension installed, but still let the main tachiyomi app control
+ * things.
+ */
+class ManhuaguiUrlActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val pathSegments = intent?.data?.pathSegments
+        if (pathSegments != null && pathSegments.size > 1) {
+            val titleid = pathSegments[1]
+            val mainIntent = Intent().apply {
+                action = "eu.kanade.tachiyomi.SEARCH"
+                putExtra("query", "${Manhuagui.PREFIX_ID_SEARCH}$titleid")
+                putExtra("filter", packageName)
+            }
+
+            try {
+                startActivity(mainIntent)
+            } catch (e: ActivityNotFoundException) {
+                Log.e("ManhuaguiUrlActivity", e.toString())
+            }
+        } else {
+            Log.e("ManhuaguiUrlActivity", "could not parse uri from intent $intent")
+        }
+
+        finish()
+        exitProcess(0)
+    }
+}


### PR DESCRIPTION
I'm getting IP ban by Manhuagui every time I update my library. So I separate the ratelimit for main website (with aggressive request limit) and image CDN and add preferences to config them.