### PR TITLE
Add ability to flag extension as NSFW

### DIFF
--- a/.travis/create-repo.sh
+++ b/.travis/create-repo.sh
@@ -15,12 +15,13 @@ APKS=( ../apk/*".apk"* )
 
 for APK in ${APKS[@]}; do
     FILENAME=$(basename ${APK})
-    BADGING="$(${TOOLS}/aapt dump badging $APK)"
+    BADGING="$(${TOOLS}/aapt dump --include-meta-data badging $APK)"
 
     PACKAGE=$(echo "$BADGING" | grep package:)
     PKGNAME=$(echo $PACKAGE | grep -Po "package: name='\K[^']+")
     VCODE=$(echo $PACKAGE | grep -Po "versionCode='\K[^']+")
     VNAME=$(echo $PACKAGE | grep -Po "versionName='\K[^']+")
+    NSFW=$(echo $BADGING | grep -Po "tachiyomi.extension.nsfw' value='\K[^']+")
 
     APPLICATION=$(echo "$BADGING" | grep application:)
     LABEL=$(echo $APPLICATION | grep -Po "label='\K[^']+")
@@ -37,7 +38,8 @@ for APK in ${APKS[@]}; do
         --arg lang "$LANG" \
         --argjson code $VCODE \
         --arg version "$VNAME" \
-        '{name:$name, pkg:$pkg, apk:$apk, lang:$lang, code:$code, version:$version}'
+        --argjson nsfw $NSFW \
+        '{name:$name, pkg:$pkg, apk:$apk, lang:$lang, code:$code, version:$version, nsfw:$nsfw}'
 
 done | jq -sr '[.[]]' > index.json
 

--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <application android:icon="@mipmap/ic_launcher" android:allowBackup="false" android:label="${appName}">
 
         <meta-data android:name="tachiyomi.extension.class" android:value="${extClass}" />
+        <meta-data android:name="tachiyomi.extension.nsfw" android:value="${nsfw}" />
 
     </application>
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -75,6 +75,7 @@ ext {
     extClass = '.<MySourceName>'
     extVersionCode = 1
     libVersion = '1.2'
+    containsNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"
@@ -87,6 +88,7 @@ apply from: "$rootDir/common.gradle"
 | `extClass` | Points to the class that implements `Source`. You can use a relative path starting with a dot (the package name is the base path). This is used to find and instantiate the source(s). |
 | `extVersionCode` | The extension version code. This must be a positive integer and incremented with any change to the code. |
 | `libVersion` | The version of the [extensions library](https://github.com/tachiyomiorg/extensions-lib) used. |
+| `containsNsfw` | (Optional, defaults to `false`) Flag to indicate that a source contains NSFW content. |
 
 The extension's version name is generated automatically by concatenating `libVersion` and `extVersionCode`. With the example used above, the version would be `1.2.1`.
 

--- a/common.gradle
+++ b/common.gradle
@@ -40,6 +40,7 @@ android {
         manifestPlaceholders = [
                 appName : "Tachiyomi: $extName",
                 extClass: extClass,
+                nsfw: project.ext.properties.getOrDefault("containsNsfw", false) ? 1 : 0,
         ]
     }
 
@@ -48,12 +49,12 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = 1.8
-        targetCompatibility = 1.8
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     kotlinOptions {
-        jvmTarget = "1.8"
+        jvmTarget = JavaVersion.VERSION_1_8.toString()
     }
 }
 

--- a/src/all/nhentai/build.gradle
+++ b/src/all/nhentai/build.gradle
@@ -7,6 +7,7 @@ ext {
     extClass = '.NHFactory'
     extVersionCode = 27
     libVersion = '1.2'
+    containsNsfw = true
 }
 
 dependencies {


### PR DESCRIPTION
Works towards https://github.com/inorichi/tachiyomi/issues/1312

---

Extension is listed as NSFW:

```json
  {
    "name": "Tachiyomi: NHentai",
    "pkg": "eu.kanade.tachiyomi.extension.all.nhentai",
    "apk": "tachiyomi-all.nhentai-v1.2.27.apk",
    "lang": "all",
    "code": 27,
    "version": "1.2.27",
    "nsfw": 1
  },
```

And example of non-flagged extension:

```json
  {
    "name": "Tachiyomi: Mangasee",
    "pkg": "eu.kanade.tachiyomi.extension.en.mangasee",
    "apk": "tachiyomi-en.mangasee-v1.2.12.apk",
    "lang": "en",
    "code": 12,
    "version": "1.2.12",
    "nsfw": 0
  },
```

---

Tested locally on my Mac.

Note that you must install `bash` and GNU `grep` (i.e. `ggrep`) via homebrew to run the build scripts properly.