### PR TITLE
Add ability to flag individual sources as NSFW

### DIFF
--- a/annotations/src/main/kotlin/Nsfw.kt
+++ b/annotations/src/main/kotlin/Nsfw.kt
@@ -1,0 +1,5 @@
+package eu.kanade.tachiyomi.annotations
+
+@Retention(AnnotationRetention.RUNTIME)
+@Target(AnnotationTarget.CLASS)
+annotation class Nsfw

--- a/common.gradle
+++ b/common.gradle
@@ -63,7 +63,7 @@ repositories {
 }
 
 dependencies {
-    compileOnly project(":annotations")
+    implementation project(":annotations")
 
     // Lib 1.2, but using specific commit so we don't need to bump up the version
     compileOnly "com.github.tachiyomiorg:extensions-lib:a596412"

--- a/src/all/madara/build.gradle
+++ b/src/all/madara/build.gradle
@@ -7,6 +7,7 @@ ext {
     extClass = '.MadaraFactory'
     extVersionCode = 126
     libVersion = '1.2'
+    containsNsfw = true
 }
 
 apply from: "$rootDir/common.gradle"

--- a/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
+++ b/src/all/madara/src/eu/kanade/tachiyomi/extension/all/madara/MadaraFactory.kt
@@ -2,6 +2,7 @@ package eu.kanade.tachiyomi.extension.all.madara
 
 import android.annotation.SuppressLint
 import eu.kanade.tachiyomi.annotations.MultiSource
+import eu.kanade.tachiyomi.annotations.Nsfw
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.asObservableSuccess
 import eu.kanade.tachiyomi.source.Source
@@ -645,6 +646,7 @@ class NightComic : Madara("Night Comic", "https://nightcomic.com", "en") {
         .build()
 }
 
+@Nsfw
 class Toonily : Madara("Toonily", "https://toonily.com", "en") {
     override fun getGenreList(): List<Genre> = listOf(
         Genre("Action", "action-webtoon"),
@@ -1197,6 +1199,7 @@ class AsgardTeam : Madara("Asgard Team", "https://www.asgard1team.com", "ar")
 
 class Skymanga : Madara("Skymanga", "https://skymanga.co", "en")
 
+@Nsfw
 class ToonilyNet : Madara("Toonily.net", "https://toonily.net", "en")
 
 class BestManga : Madara("BestManga", "https://bestmanga.club", "ru", SimpleDateFormat("dd.MM.yyyy", Locale.getDefault()))


### PR DESCRIPTION
Allows more granular flagging within multi-source extensions.

App should be able to have different levels of managing NSFW sources, e.g.:
- Everything allowed
- Block loading sources annotated with `@Nsfw`, but still showing extensions flagged with `containsNsfw` within the extensions list; useful for things like Madara
- Block extensions flagged with `containsNsfw`, i.e. hidden from extensions list and block loading its sources even if installed