### PR TITLE
Fix guya URL activity.

### DIFF
--- a/src/en/guya/build.gradle
+++ b/src/en/guya/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Guya'
     pkgNameSuffix = "en.guya"
     extClass = '.Guya'
-    extVersionCode = 11
+    extVersionCode = 12
     libVersion = '1.2'
 }
 

--- a/src/en/guya/src/eu/kanade/tachiyomi/extension/en/guya/GuyaUrlActivity.kt
+++ b/src/en/guya/src/eu/kanade/tachiyomi/extension/en/guya/GuyaUrlActivity.kt
@@ -18,7 +18,7 @@ class GuyaUrlActivity : Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val pathSegments = intent?.data?.pathSegments
-        if (pathSegments != null && pathSegments.size == 3) {
+        if (pathSegments != null && pathSegments.size >= 3) {
             val slug = pathSegments[2]
 
             // Gotta do it like this since slug title != actual title


### PR DESCRIPTION
The url fragments can have more than 3 items. 

Tested locally, confirmed working.