### PR TITLE
Fix issue with old manga on Newtoki's .net domain + thumbnails

### DIFF
--- a/src/ko/newtoki/build.gradle
+++ b/src/ko/newtoki/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'NewToki'
     pkgNameSuffix = 'ko.newtoki'
     extClass = '.NewTokiFactory'
-    extVersionCode = 12
+    extVersionCode = 13
     libVersion = '1.2'
 }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -9,9 +9,15 @@ import android.widget.Toast
 import eu.kanade.tachiyomi.extension.BuildConfig
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.ConfigurableSource
-import eu.kanade.tachiyomi.source.model.*
+import eu.kanade.tachiyomi.source.model.FilterList
+import eu.kanade.tachiyomi.source.model.MangasPage
+import eu.kanade.tachiyomi.source.model.Page
+import eu.kanade.tachiyomi.source.model.SChapter
+import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
+import java.text.SimpleDateFormat
+import java.util.Calendar
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -19,8 +25,6 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
-import java.text.SimpleDateFormat
-import java.util.*
 
 /**
  * NewToki Source

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -9,15 +9,9 @@ import android.widget.Toast
 import eu.kanade.tachiyomi.extension.BuildConfig
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.source.ConfigurableSource
-import eu.kanade.tachiyomi.source.model.FilterList
-import eu.kanade.tachiyomi.source.model.MangasPage
-import eu.kanade.tachiyomi.source.model.Page
-import eu.kanade.tachiyomi.source.model.SChapter
-import eu.kanade.tachiyomi.source.model.SManga
+import eu.kanade.tachiyomi.source.model.*
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import eu.kanade.tachiyomi.util.asJsoup
-import java.text.SimpleDateFormat
-import java.util.Calendar
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -25,6 +19,8 @@ import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
 import uy.kohesive.injekt.Injekt
 import uy.kohesive.injekt.api.get
+import java.text.SimpleDateFormat
+import java.util.*
 
 /**
  * NewToki Source
@@ -77,6 +73,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
     override fun mangaDetailsParse(document: Document): SManga {
         val info = document.select("div.view-title > .view-content").first()
         val title = document.select("div.view-content > span > b").text()
+        val thumbnail = document.select("div.row div.view-img > img").attr("src")
         val descriptionElement = info.select("div.row div.view-content:not([style])")
         val description = descriptionElement.map {
             it.text().trim()
@@ -85,6 +82,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
         val manga = SManga.create()
         manga.title = title
         manga.description = description.joinToString("\n")
+        manga.thumbnail_url = thumbnail
         descriptionElement.forEach {
             val text = it.text()
             when {
@@ -164,8 +162,8 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("article > div > div > img")
-            .filterNot { it.attr("data-original").contains("blank.gif") }
+        return document.select("article > div  div > img")
+            .filterNot { !it.hasAttr("data-original") || it.attr("data-original").contains("blank.gif") }
             .mapIndexed { i, img -> Page(i, "", img.attr("abs:data-original")) }
     }
 


### PR DESCRIPTION
v1.2.13
====
* Fix page list empty issue on old mangas in `.net` domain
  - This caused by chapter has 3 divs to access it. recent Chs are only have 2 div btw.
* Fix thumbnail on detail page.

-----
Hello, long time no see.
Manamoa is currently down. but seems... more like _taken down_ now.

I didn't managed korean extensions except for manamoa. Even created by myself
As i'm fan of manga and Manamoa was great korean translation source for it.

When i didn't managing this extension, many people who loves webtoon(manhwa, on `.com` domain) still maintaining this one.
But as there's many alternative sources about manga, the manga side is bit broken(The site not changed much... so it worked)

...
just in short word, For now, Manamoa is down, And I will maintain this extension again.
