### PR TITLE
Update Newtoki Extension v1.2.14

### DIFF
--- a/src/ko/newtoki/build.gradle
+++ b/src/ko/newtoki/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'NewToki'
     pkgNameSuffix = 'ko.newtoki'
     extClass = '.NewTokiFactory'
-    extVersionCode = 13
+    extVersionCode = 14
     libVersion = '1.2'
 }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -166,7 +166,8 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
     }
 
     override fun pageListParse(document: Document): List<Page> {
-        return document.select("article > div  div > img")
+        // <article> - <div> - optional <div> - <div> - optional <p> - <img>
+        return document.select("article > div  div img")
             .filterNot { !it.hasAttr("data-original") || it.attr("data-original").contains("blank.gif") }
             .mapIndexed { i, img -> Page(i, "", img.attr("abs:data-original")) }
     }

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -41,7 +41,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
         val linkElement = element.getElementsByTag("a").first()
 
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(linkElement.attr("href"))
+        manga.setUrlWithoutDomain(linkElement.attr("href").substringAfter("?"))
         manga.title = element.select("span.title").first().ownText()
         manga.thumbnail_url = linkElement.getElementsByTag("img").attr("src")
         return manga
@@ -167,7 +167,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
 
     override fun pageListParse(document: Document): List<Page> {
         // <article> - <div> - optional <div> - <div> - optional <p> - <img>
-        return document.select("article > div  div img")
+        return document.select("article > div div img")
             .filterNot { !it.hasAttr("data-original") || it.attr("data-original").contains("blank.gif") }
             .mapIndexed { i, img -> Page(i, "", img.attr("abs:data-original")) }
     }

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -41,7 +41,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
         val linkElement = element.getElementsByTag("a").first()
 
         val manga = SManga.create()
-        manga.setUrlWithoutDomain(linkElement.attr("href").substringAfter("?"))
+        manga.setUrlWithoutDomain(linkElement.attr("href").substringBefore("?"))
         manga.title = element.select("span.title").first().ownText()
         manga.thumbnail_url = linkElement.getElementsByTag("img").attr("src")
         return manga

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.source.SourceFactory
 import eu.kanade.tachiyomi.source.model.Filter
 import eu.kanade.tachiyomi.source.model.FilterList
 import eu.kanade.tachiyomi.source.model.Page
+import java.security.MessageDigest
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
@@ -17,6 +18,10 @@ import org.jsoup.nodes.Document
 /**
  * Source changes domain names every few days (e.g. newtoki31.net to newtoki32.net)
  * The domain name was newtoki32 on 2019-11-14, this attempts to match the rate at which the domain changes
+ *
+ * Since 2020-09-20, They changed manga side to Manatoki.
+ * It was merged after shutdown of ManaMoa.
+ * This is by the head of Manamoa, as thety decided to move to Newtoki.
  */
 private val domainNumber = 32 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
 
@@ -27,9 +32,25 @@ class NewTokiFactory : SourceFactory {
     )
 }
 
-class NewTokiManga : NewToki("NewToki", "https://newtoki$domainNumber.net", "comic")
+class NewTokiManga : NewToki("ManaToki", "https://manatoki$domainNumber.net", "comic") {
+    override val id by lazy {
+        // / ! DO NOT CHANGE THIS !  Only the site name changed from newtoki.
+        val oldName = "NewToki"
+        val key = "${oldName.toLowerCase()}/$lang/$versionId"
+        val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
+        (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
+    }
+}
 
-class NewTokiWebtoon : NewToki("NewToki (Webtoon)", "https://newtoki$domainNumber.com", "webtoon") {
+class NewTokiWebtoon : NewToki("NewToki", "https://newtoki$domainNumber.com", "webtoon") {
+    override val id by lazy {
+        // / ! DO NOT CHANGE THIS !  Prevent to treating as a new site
+        val oldName = "NewToki (Webtoon)"
+        val key = "${oldName.toLowerCase()}/$lang/$versionId"
+        val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
+        (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
+    }
+
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = HttpUrl.parse("$baseUrl/webtoon" + (if (page > 1) "/p$page" else ""))!!.newBuilder()
         filters.forEach { filter ->

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -23,7 +23,7 @@ import org.jsoup.nodes.Document
  * It was merged after shutdown of ManaMoa.
  * This is by the head of Manamoa, as thety decided to move to Newtoki.
  */
-private val domainNumber = 32 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
+private val domainNumber = 59 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
 
 class NewTokiFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(
@@ -33,23 +33,13 @@ class NewTokiFactory : SourceFactory {
 }
 
 class NewTokiManga : NewToki("ManaToki", "https://manatoki$domainNumber.net", "comic") {
-    override val id by lazy {
-        // / ! DO NOT CHANGE THIS !  Only the site name changed from newtoki.
-        val oldName = "NewToki"
-        val key = "${oldName.toLowerCase()}/$lang/$versionId"
-        val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
-        (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
-    }
+    // / ! DO NOT CHANGE THIS !  Only the site name changed from newtoki.
+    override val id by lazy { generateSourceId("NewToki", lang, versionId) }
 }
 
 class NewTokiWebtoon : NewToki("NewToki", "https://newtoki$domainNumber.com", "webtoon") {
-    override val id by lazy {
-        // / ! DO NOT CHANGE THIS !  Prevent to treating as a new site
-        val oldName = "NewToki (Webtoon)"
-        val key = "${oldName.toLowerCase()}/$lang/$versionId"
-        val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
-        (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
-    }
+    // / ! DO NOT CHANGE THIS !  Prevent to treating as a new site
+    override val id by lazy { generateSourceId("NewToki (Webtoon)", lang, versionId) }
 
     override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
         val url = HttpUrl.parse("$baseUrl/webtoon" + (if (page > 1) "/p$page" else ""))!!.newBuilder()
@@ -89,4 +79,10 @@ class NewTokiWebtoon : NewToki("NewToki", "https://newtoki$domainNumber.com", "w
     override fun getFilterList() = FilterList(
             SearchTypeList()
     )
+}
+
+fun generateSourceId(name: String, lang: String, versionId: Int): Long {
+    val key = "${name.toLowerCase()}/$lang/$versionId"
+    val bytes = MessageDigest.getInstance("MD5").digest(key.toByteArray())
+    return (0..7).map { bytes[it].toLong() and 0xff shl 8 * (7 - it) }.reduce(Long::or) and Long.MAX_VALUE
 }

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -23,7 +23,7 @@ import org.jsoup.nodes.Document
  * It was merged after shutdown of ManaMoa.
  * This is by the head of Manamoa, as they decided to move to Newtoki.
  */
-private val domainNumber = 59 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
+private val domainNumber = 33 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
 
 class NewTokiFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -35,6 +35,117 @@ class NewTokiFactory : SourceFactory {
 class NewTokiManga : NewToki("ManaToki", "https://manatoki$domainNumber.net", "comic") {
     // / ! DO NOT CHANGE THIS !  Only the site name changed from newtoki.
     override val id by lazy { generateSourceId("NewToki", lang, versionId) }
+
+    override fun searchMangaRequest(page: Int, query: String, filters: FilterList): Request {
+        val url = HttpUrl.parse("$baseUrl/comic" + (if (page > 1) "/p$page" else ""))!!.newBuilder()
+
+        if (!query.isBlank()) {
+            url.addQueryParameter("stx", query)
+            return GET(url.toString())
+        }
+
+        filters.forEach { filter ->
+            when (filter) {
+                is SearchPublishTypeList -> {
+                    if (filter.state > 0) {
+                        url.addQueryParameter("publish", filter.values[filter.state])
+                    }
+                }
+
+                is SearchJaumTypeList -> {
+                    if (filter.state > 0) {
+                        url.addQueryParameter("jaum", filter.values[filter.state])
+                    }
+                }
+
+                is SearchGenreTypeList -> {
+                    if (filter.state > 0) {
+                        url.addQueryParameter("tag", filter.values[filter.state])
+                    }
+                }
+            }
+        }
+
+        return GET(url.toString())
+    }
+
+    // [...document.querySelectorAll("form.form td")[2].querySelectorAll("a")].map((el, i) => `"${el.innerText.trim()}"`).join(',\n')
+    private class SearchPublishTypeList : Filter.Select<String>("Publish", arrayOf(
+        "전체",
+        "미분류",
+        "주간",
+        "격주",
+        "월간",
+        "격월/비정기",
+        "단편",
+        "단행본",
+        "완결"
+    ))
+
+    // [...document.querySelectorAll("form.form td")[3].querySelectorAll("a")].map((el, i) => `"${el.innerText.trim()}"`).join(',\n')
+    private class SearchJaumTypeList : Filter.Select<String>("Jaum", arrayOf(
+        "전체",
+        "ㄱ",
+        "ㄴ",
+        "ㄷ",
+        "ㄹ",
+        "ㅁ",
+        "ㅂ",
+        "ㅅ",
+        "ㅇ",
+        "ㅈ",
+        "ㅊ",
+        "ㅋ",
+        "ㅌ",
+        "ㅍ",
+        "ㅎ",
+        "0-9",
+        "a-z"
+    ))
+
+    // [...document.querySelectorAll("form.form td")[4].querySelectorAll("a")].map((el, i) => `"${el.innerText.trim()}"`).join(',\n')
+    private class SearchGenreTypeList : Filter.Select<String>("Genre", arrayOf(
+        "전체",
+        "17",
+        "BL",
+        "SF",
+        "TS",
+        "개그",
+        "게임",
+        "공포",
+        "도박",
+        "드라마",
+        "라노벨",
+        "러브코미디",
+        "로맨스",
+        "먹방",
+        "미스터리",
+        "백합",
+        "붕탁",
+        "성인",
+        "순정",
+        "스릴러",
+        "스포츠",
+        "시대",
+        "애니화",
+        "액션",
+        "역사",
+        "음악",
+        "이세계",
+        "일상",
+        "일상+치유",
+        "전생",
+        "추리",
+        "판타지",
+        "학원",
+        "호러"
+    ))
+
+    override fun getFilterList() = FilterList(
+        SearchPublishTypeList(),
+        SearchJaumTypeList(),
+        SearchGenreTypeList()
+    )
 }
 
 class NewTokiWebtoon : NewToki("NewToki", "https://newtoki$domainNumber.com", "webtoon") {

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -21,7 +21,7 @@ import org.jsoup.nodes.Document
  *
  * Since 2020-09-20, They changed manga side to Manatoki.
  * It was merged after shutdown of ManaMoa.
- * This is by the head of Manamoa, as thety decided to move to Newtoki.
+ * This is by the head of Manamoa, as they decided to move to Newtoki.
  */
 private val domainNumber = 59 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
 


### PR DESCRIPTION
v1.2.14
=====
* Site name/domain changes
  - ManaMoa merged into NewToki's manga side. calls ManaToki.
  - Site wasn't not changed too hard so decided to keep old site ids.
* Fix issue with pages with optional \<p\> tags
* Search Filter on ManaToki side
  - The site doesn't support title search with filter. It runs separately  

----

nah idea's new ui is too complicated to me

The site is very unstable on title name search now.