### PR TITLE
MRM - Use super in headersbuilder

### DIFF
--- a/src/all/myreadingmanga/build.gradle
+++ b/src/all/myreadingmanga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MyReadingManga'
     pkgNameSuffix = 'all.myreadingmanga'
     extClass = '.MyReadingMangaFactory'
-    extVersionCode = 40
+    extVersionCode = 41
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
+++ b/src/all/myreadingmanga/src/eu/kanade/tachiyomi/extension/all/myreadingmanga/MyReadingManga.kt
@@ -38,7 +38,7 @@ open class MyReadingManga(override val lang: String, private val siteLang: Strin
         .build()!!
     override val supportsLatest = true
 
-    override fun headersBuilder(): Headers.Builder = Headers.Builder()
+    override fun headersBuilder(): Headers.Builder = super.headersBuilder()
         .add("Referer", baseUrl)
 
     // Popular - Random


### PR DESCRIPTION
I was having trouble bypassing the captcha in webview. 

This switches Headers.Builder() to super.headersBuilder() to inherit existing headers such as user agent.
