### PR TITLE
MangaFast: ignore unparseable dates

### DIFF
--- a/src/en/mangafast/build.gradle
+++ b/src/en/mangafast/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'MangaFast'
     pkgNameSuffix = 'en.mangafast'
     extClass = '.MangaFast'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/en/mangafast/src/eu/kanade/tachiyomi/extension/en/mangafast/MangaFast.kt
+++ b/src/en/mangafast/src/eu/kanade/tachiyomi/extension/en/mangafast/MangaFast.kt
@@ -8,6 +8,7 @@ import eu.kanade.tachiyomi.source.model.SManga
 import eu.kanade.tachiyomi.source.online.ParsedHttpSource
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
+import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Locale
 
@@ -70,7 +71,15 @@ class MangaFast : ParsedHttpSource() {
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.select("a").attr("href"))
         name = element.select("a").attr("title")
-        date_upload = dateFormat.parse(element.select("td.tgs").text().trim())?.time ?: 0
+        date_upload = parseDate(element.select("td.tgs").text())
+    }
+
+    private fun parseDate(text: String): Long {
+        return try {
+            dateFormat.parse(text.trim())?.time ?: 0L
+        } catch (pe: ParseException) { // this can happen for spoiler & release date entries
+            0L
+        }
     }
 
     companion object {

--- a/src/en/mangafast/src/eu/kanade/tachiyomi/extension/en/mangafast/MangaFast.kt
+++ b/src/en/mangafast/src/eu/kanade/tachiyomi/extension/en/mangafast/MangaFast.kt
@@ -66,7 +66,7 @@ class MangaFast : ParsedHttpSource() {
         else -> SManga.UNKNOWN
     }
 
-    override fun chapterListSelector() = "tr:has(td.tgs)"
+    override fun chapterListSelector() = "tr:has(td.tgs:matches(\\d{4}-\\d{2}-\\d{2}))"
 
     override fun chapterFromElement(element: Element) = SChapter.create().apply {
         setUrlWithoutDomain(element.select("a").attr("href"))


### PR DESCRIPTION
Fixes #4346

MangaFast introduced the concept of teaser chapters and placeholders for upcoming chapters. These do not have a proper date and previously led to a ParseException.

Ideally the extension would mark those chapters as teasers and in case of placeholders just skip them, but I couldn't think of a way to do so.


 