### PR TITLE
Update NewToki Extension v1.2.15

### DIFF
--- a/src/ko/newtoki/build.gradle
+++ b/src/ko/newtoki/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'NewToki'
     pkgNameSuffix = 'ko.newtoki'
     extClass = '.NewTokiFactory'
-    extVersionCode = 14
+    extVersionCode = 15
     libVersion = '1.2'
 }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewTokiFactory.kt
@@ -23,7 +23,7 @@ import java.util.Locale
  * It was merged after shutdown of ManaMoa.
  * This is by the head of Manamoa, as they decided to move to Newtoki.
  */
-private val domainNumber = 33 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
+private val domainNumber = 32 + ((Date().time - SimpleDateFormat("yyyy-MM-dd", Locale.US).parse("2019-11-14")!!.time) / 595000000)
 
 class NewTokiFactory : SourceFactory {
     override fun createSources(): List<Source> = listOf(


### PR DESCRIPTION
v1.2.15
=====
* Fix domain number again.
   - It keeps jumping unusually.
* Initial ID support added for both side.
  - The site search is *\*very\** unstable now so this would help.
  - Note that ID is shares chapters too.