### PR TITLE
Update NewToki Extension v1.2.18

### DIFF
--- a/src/ko/newtoki/build.gradle
+++ b/src/ko/newtoki/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'NewToki / ManaToki(ManaMoa)'
     pkgNameSuffix = 'ko.newtoki'
     extClass = '.NewTokiFactory'
-    extVersionCode = 17
+    extVersionCode = 18
     libVersion = '1.2'
 }
 

--- a/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
+++ b/src/ko/newtoki/src/eu/kanade/tachiyomi/extension/ko/newtoki/NewToki.kt
@@ -218,7 +218,7 @@ open class NewToki(override val name: String, private val defaultBaseUrl: String
             .flatMap { it.split(".") }
             .joinToString("") { it.toIntOrNull(16)?.toChar()?.toString() ?: "" }
             .let { Jsoup.parse(it) }
-            .select("img[alt]")
+            .select("img[src=/img/loading-image.gif]")
             .mapIndexed { i, img -> Page(i, "", if (img.hasAttr(dataAttr)) img.attr(dataAttr) else img.attr("abs:content")) }
     }
 


### PR DESCRIPTION
Fix page list empty.
This will breaks old manga a bit but recent should ok.