### PR TITLE
Komga:dto: Fix seriesIds being casted to Long when fetching collections.

### DIFF
--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Fix seriesIds being casted to Long when fetching collections.
 
+Minimum Komga version required: `0.59.0`
+
 ## 1.2.16
 
 Minimum Komga version required: `0.59.0`

--- a/src/all/komga/CHANGELOG.md
+++ b/src/all/komga/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.17
+
+* Fix seriesIds being casted to Long when fetching collections.
+
 ## 1.2.16
 
 Minimum Komga version required: `0.59.0`

--- a/src/all/komga/build.gradle
+++ b/src/all/komga/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Komga'
     pkgNameSuffix = 'all.komga'
     extClass = '.KomgaFactory'
-    extVersionCode = 16
+    extVersionCode = 17
     libVersion = '1.2'
 }
 

--- a/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
+++ b/src/all/komga/src/eu/kanade/tachiyomi/extension/all/komga/dto/Dto.kt
@@ -88,7 +88,7 @@ data class CollectionDto(
     val id: String,
     val name: String,
     val ordered: Boolean,
-    val seriesIds: List<Long>,
+    val seriesIds: List<String>,
     val createdDate: String,
     val lastModifiedDate: String,
     val filtered: Boolean


### PR DESCRIPTION
@gotson Request for Validation.

There wasn't much to do, changing this seemed to have worked, I believe it will work for the older versions as well.

Note that I also updated the extension version as per the guidelines. 
---

Commit Message:
```
This Fixes:

- Collections Unable to be Fetched from newly created Komga Servers that use a string for seriesID.
```