### PR TITLE
Update domain from 9hentai.com to .ru

### DIFF
--- a/src/all/ninehentai/build.gradle
+++ b/src/all/ninehentai/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'NineHentai'
     pkgNameSuffix = 'all.ninehentai'
     extClass = '.NineHentai'
-    extVersionCode = 7
+    extVersionCode = 8
     libVersion = '1.2'
     containsNsfw = true
 }

--- a/src/all/ninehentai/src/eu/kanade/tachiyomi/extension/all/ninehentai/NineHentai.kt
+++ b/src/all/ninehentai/src/eu/kanade/tachiyomi/extension/all/ninehentai/NineHentai.kt
@@ -29,7 +29,7 @@ import java.util.Date
 @Nsfw
 class NineHentai : HttpSource() {
 
-    override val baseUrl = "https://9hentai.com"
+    override val baseUrl = "https://9hentai.ru"
 
     override val name = "NineHentai"
 


### PR DESCRIPTION
Should fix issue #4579

<!--
If you are updating extensions, please remember to update the `extVersionCode` value in their `build.gradle` files as well.

Please also mention the related issues, e.g.:

Closes #123
Closes #456
-->
