### PR TITLE
NovelleLeggere - fixing duplicated page images

### DIFF
--- a/src/it/novelleleggere/build.gradle
+++ b/src/it/novelleleggere/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Novelle Leggere'
     pkgNameSuffix = 'it.novelleleggere'
     extClass = '.NovelleLeggere'
-    extVersionCode = 1
+    extVersionCode = 2
     libVersion = '1.2'
 }
 

--- a/src/it/novelleleggere/src/eu/kanade/tachiyomi/extension/it/novelleleggere/NovelleLeggere.kt
+++ b/src/it/novelleleggere/src/eu/kanade/tachiyomi/extension/it/novelleleggere/NovelleLeggere.kt
@@ -71,7 +71,7 @@ class NovelleLeggere : ParsedHttpSource() {
 
     // Pages
     override fun pageListParse(document: Document): List<Page> = mutableListOf<Page>().apply {
-        document.select("div.post-content p img").forEachIndexed { index, element ->
+        document.select("div.post-content p>img").forEachIndexed { index, element ->
             add(Page(index, "", element.attr("abs:src").substringBefore("?")))
         }
     }


### PR DESCRIPTION
Small fix to pageListParse selector to ignore <noscript> img duplicate