### PR TITLE
Webtoon - Indonesia update

### DIFF
--- a/src/all/webtoons/build.gradle
+++ b/src/all/webtoons/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Webtoons'
     pkgNameSuffix = 'all.webtoons'
     extClass = '.WebtoonsFactory'
-    extVersionCode = 20
+    extVersionCode = 21
     libVersion = '1.2'
 }
 

--- a/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
+++ b/src/all/webtoons/src/eu/kanade/tachiyomi/extension/all/webtoons/WebtoonsFactory.kt
@@ -3,7 +3,6 @@ package eu.kanade.tachiyomi.extension.all.webtoons
 import eu.kanade.tachiyomi.source.Source
 import eu.kanade.tachiyomi.source.SourceFactory
 import java.text.SimpleDateFormat
-import java.util.GregorianCalendar
 import java.util.Locale
 
 class WebtoonsFactory : SourceFactory {
@@ -20,7 +19,7 @@ class WebtoonsFactory : SourceFactory {
         WebtoonsTranslate("zh", "CMN", " (Simplified)"),
         WebtoonsTranslate("zh", "CMT", " (Traditional)"),
         WebtoonsTranslate("th", "THA"),
-        WebtoonsTranslate("in", "IND"),
+        WebtoonsTranslate("id", "IND"),
         WebtoonsTranslate("fr", "FRA"),
         WebtoonsTranslate("vi", "VIE"),
         WebtoonsTranslate("ru", "RUS"),
@@ -52,21 +51,8 @@ class WebtoonsFactory : SourceFactory {
 
 class WebtoonsEnglish : WebtoonsDefault("en")
 
-class WebtoonsIndonesian : WebtoonsDefault("in", "id") {
+class WebtoonsIndonesian : WebtoonsDefault("id", dateFormat = SimpleDateFormat("yyyy MMM dd", Locale("id"))) {
     override val name: String = "Webtoons.com (Indonesian)"
-
-    // Android seems to be unable to parse Indonesian dates; we'll use a short hard-coded table
-    // instead.
-    private val dateMap: Array<String> = arrayOf(
-        "Jan", "Feb", "Mar", "Apr", "Mei", "Jun", "Jul", "Agu", "Sep", "Okt", "Nov", "Des"
-    )
-
-    override fun chapterParseDate(date: String): Long {
-        val expr = Regex("""(\d{4}) ([A-Z][a-z]{2}) (\d+)""").find(date) ?: return 0
-        val (_, year, monthString, day) = expr.groupValues
-        val monthIndex = dateMap.indexOf(monthString)
-        return GregorianCalendar(year.toInt(), monthIndex, day.toInt()).time.time
-    }
 }
 
 class WebtoonsThai : WebtoonsDefault("th", dateFormat = SimpleDateFormat("d MMM yyyy", Locale("th")))


### PR DESCRIPTION
- fix webtoon indonesia not appear in indonesia language, instead create another indonesia language
- replace hardcode date-format (indonesia)

*need to migrate after update, since the source from "fake" "indonesia" will disappear. "moved for the better future"
