### PR TITLE
Update manga and API endpoints at Tsuki

### DIFF
--- a/src/pt/tsukimangas/build.gradle
+++ b/src/pt/tsukimangas/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Tsuki Mangás'
     pkgNameSuffix = 'pt.tsukimangas'
     extClass = '.TsukiMangas'
-    extVersionCode = 6
+    extVersionCode = 7
     libVersion = '1.2'
 }
 


### PR DESCRIPTION
Closes #5050.

Existing mangas in library will have to be migrated (from Tsuki to Tsuki) to update the URL.