### PR TITLE
Dilbert: Fix (#4634)

### DIFF
--- a/src/en/dilbert/build.gradle
+++ b/src/en/dilbert/build.gradle
@@ -5,7 +5,7 @@ ext {
     extName = 'Dilbert'
     pkgNameSuffix = 'en.dilbert'
     extClass = '.Dilbert'
-    extVersionCode = 2
+    extVersionCode = 3
     libVersion = '1.2'
 }
 

--- a/src/en/dilbert/src/eu/kanade/tachiyomi/extension/en/dilbert/Dilbert.kt
+++ b/src/en/dilbert/src/eu/kanade/tachiyomi/extension/en/dilbert/Dilbert.kt
@@ -111,7 +111,7 @@ class Dilbert : ParsedHttpSource() {
     override fun imageUrlRequest(page: Page) = GET(page.url, headers)
 
     override fun imageUrlParse(document: Document) =
-        "https:" + document.first(".img-comic").attr("src")
+        document.first(".img-comic").attr("src")
 
     private val SManga.year: Int
         get() = url.substringAfterLast('?').toInt()


### PR DESCRIPTION
Closes #4634 

With the previous method "https" was added to the image url.
Now that method adds another "https" before the https of the url (they have probably updated their website) which makes the url invalid.


