### PR TITLE
[CI SKIP] date_upload is in miliseconds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,8 +207,8 @@ a.k.a. the Latest source entry point in the app (invoked by tapping on the "Late
 #### Chapter
 
 - After a chapter list for the manga is fetched and the app is going to cache the data, `prepareNewChapter` will be called.
-- `SChapter.date_upload` is in the [UNIX Epoch time](https://en.wikipedia.org/wiki/Unix_time) format.
-    - If you don't pass `SChapter.date_upload`, the user won't get notifications for new chapters. refer to [this issue](https://github.com/inorichi/tachiyomi/issues/2089) for more info.
+- `SChapter.date_upload` is the [UNIX Epoch time](https://en.wikipedia.org/wiki/Unix_time) **expressed in miliseconds**.
+    - If you don't pass `SChapter.date_upload`, the user won't get notifications for new chapters. refer to [this issue](https://github.com/inorichi/tachiyomi/issues/2089) for more info. `System.currentTimeMillis()` works as a substitute when real data is not available. 
 
 #### Chapter Pages
 


### PR DESCRIPTION
additional info:
mangadex api gives time in epoch format but we are multiplying it by 1000
ref: https://github.com/inorichi/tachiyomi-extensions/blob/bb131790df4adfac5dd788eb1363fa30a3696f53/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/MangaDex.kt#L540-L541
